### PR TITLE
Support local storage pointers

### DIFF
--- a/libsolidity/ast/ASTBoogieConverter.cpp
+++ b/libsolidity/ast/ASTBoogieConverter.cpp
@@ -1383,7 +1383,7 @@ bool ASTBoogieConverter::visit(VariableDeclarationStatement const& _node)
 			bg::Expr::Ref init = convertExpression(*initialValue);
 			m_currentBlocks.top()->addStmt(bg::Stmt::comment("Packing local storage pointer " + declarations[0]->name()));
 
-			auto packed = ASTBoogieUtils::pack(initialValue, init, &_node, m_context);
+			auto packed = ASTBoogieUtils::pack(initialValue, init, m_context);
 			m_localDecls.push_back(packed.ptr);
 			for (auto stmt: packed.stmts)
 				m_currentBlocks.top()->addStmt(stmt);

--- a/libsolidity/ast/ASTBoogieConverter.cpp
+++ b/libsolidity/ast/ASTBoogieConverter.cpp
@@ -27,7 +27,7 @@ namespace solidity
 
 bg::Expr::Ref ASTBoogieConverter::convertExpression(Expression const& _node)
 {
-	ASTBoogieExpressionConverter::Result result = ASTBoogieExpressionConverter(m_context, m_currentContract).convert(_node);
+	ASTBoogieExpressionConverter::Result result = ASTBoogieExpressionConverter(m_context).convert(_node);
 
 	m_localDecls.insert(end(m_localDecls), begin(result.newDecls), end(result.newDecls));
 	for (auto tcc: result.tccs)
@@ -211,15 +211,15 @@ void ASTBoogieConverter::constructorPreamble(ASTNode const& _scope)
 
 	// Initialize state variables first, must be done for
 	// base class members as well
-	for (auto contract: m_currentContract->annotation().linearizedBaseContracts)
+	for (auto contract: m_context.currentContract()->annotation().linearizedBaseContracts)
 		for (auto sv: ASTNode::filteredNodes<VariableDeclaration>(contract->subNodes()))
 			initializeStateVar(*sv, _scope);
 
 	int pushedScopes = 0;
 	// First initialize the arguments from derived to base
-	for (auto base: m_currentContract->annotation().linearizedBaseContracts)
+	for (auto base: m_context.currentContract()->annotation().linearizedBaseContracts)
 	{
-		if (base == m_currentContract)
+		if (base == m_context.currentContract())
 			continue; // Only include base statements, not ours
 
 		// Check if base has a constructor
@@ -236,8 +236,8 @@ void ASTBoogieConverter::constructorPreamble(ASTNode const& _scope)
 
 		// Try to get the argument list (from either inheritance specifiers or modifiers)
 		std::vector<ASTPointer<Expression>> const* argsList = nullptr;
-		auto constrArgs = m_currentContract->annotation().baseConstructorArguments.find(baseConstr);
-		if (constrArgs != m_currentContract->annotation().baseConstructorArguments.end())
+		auto constrArgs = m_context.currentContract()->annotation().baseConstructorArguments.find(baseConstr);
+		if (constrArgs != m_context.currentContract()->annotation().baseConstructorArguments.end())
 		{
 			if (auto ispec = dynamic_cast<InheritanceSpecifier const*>(constrArgs->second))
 				argsList = ispec->arguments(); // Inheritance specifier
@@ -270,11 +270,11 @@ void ASTBoogieConverter::constructorPreamble(ASTNode const& _scope)
 	}
 
 	// Second, inline the bodies from base to derived
-	for (auto it = m_currentContract->annotation().linearizedBaseContracts.rbegin();
-			it != m_currentContract->annotation().linearizedBaseContracts.rend(); ++it)
+	for (auto it = m_context.currentContract()->annotation().linearizedBaseContracts.rbegin();
+			it != m_context.currentContract()->annotation().linearizedBaseContracts.rend(); ++it)
 	{
 		auto base = *it;
-		if (base == m_currentContract)
+		if (base == m_context.currentContract())
 			continue; // Only include base statements, not ours
 
 		// Check if base has a constructor
@@ -391,7 +391,7 @@ bool ASTBoogieConverter::parseExpr(string exprStr, ASTNode const& _node, ASTNode
 	// are pointing to positions in the docstring
 	ErrorList errorList;
 	ErrorReporter errorReporter(errorList);
-	TypeChecker typeChecker(m_context.evmVersion(), errorReporter, m_currentContract);
+	TypeChecker typeChecker(m_context.evmVersion(), errorReporter, m_context.currentContract());
 
 	ErrorReporter* originalErrReporter = m_context.errorReporter();
 	m_context.errorReporter() = &errorReporter;
@@ -414,7 +414,7 @@ bool ASTBoogieConverter::parseExpr(string exprStr, ASTNode const& _node, ASTNode
 			if (typeChecker.checkTypeRequirements(*expr))
 			{
 				// Convert expression to Boogie representation
-				auto convResult = ASTBoogieExpressionConverter(m_context, m_currentContract).convert(*expr);
+				auto convResult = ASTBoogieExpressionConverter(m_context).convert(*expr);
 				result.expr = convResult.expr;
 				result.exprStr = exprStr;
 				result.exprSol = expr;
@@ -575,7 +575,7 @@ void ASTBoogieConverter::addModifiesSpecs(FunctionDefinition const& _node, bg::P
 	if (m_context.modAnalysis() && !_node.isConstructor() && !canModifyAll)
 	{
 		// Linearized base contracts include the current contract as well
-		for (auto contract: m_currentContract->annotation().linearizedBaseContracts)
+		for (auto contract: m_context.currentContract()->annotation().linearizedBaseContracts)
 		{
 			for (auto varDecl: ASTNode::filteredNodes<VariableDeclaration>(contract->subNodes()))
 			{
@@ -603,7 +603,7 @@ void ASTBoogieConverter::addModifiesSpecs(FunctionDefinition const& _node, bg::P
 
 				expr = bg::Expr::eq(varThis, expr);
 				string varName = varDecl->name();
-				if (m_currentContract->annotation().linearizedBaseContracts.size() > 1)
+				if (m_context.currentContract()->annotation().linearizedBaseContracts.size() > 1)
 					varName = contract->name() + "::" + varName;
 				procDecl->getEnsures().push_back(bg::Specification::spec(expr,
 						ASTBoogieUtils::createAttrs(_node.location(), "Function might modify '" + varName + "' illegally", *m_context.currentScanner())));
@@ -674,7 +674,6 @@ void ASTBoogieConverter::processFuncModifiersAndBody()
 
 ASTBoogieConverter::ASTBoogieConverter(BoogieContext& context) :
 				m_context(context),
-				m_currentContract(nullptr),
 				m_currentFunc(nullptr),
 				m_currentModifier(0),
 				m_currentRet(nullptr),
@@ -714,7 +713,7 @@ bool ASTBoogieConverter::visit(ContractDefinition const& _node)
 {
 	rememberScope(_node);
 
-	m_currentContract = &_node;
+	m_context.setCurrentContract(&_node);
 	// Boogie programs are flat, contracts do not appear explicitly
 	m_context.addGlobalComment("\n------- Contract: " + _node.name() + " -------");
 
@@ -920,7 +919,7 @@ bool ASTBoogieConverter::visit(FunctionDefinition const& _node)
 
 	// Get the name of the function
 	string funcName = _node.isConstructor() ?
-			ASTBoogieUtils::getConstructorName(m_currentContract) :
+			ASTBoogieUtils::getConstructorName(m_context.currentContract()) :
 			m_context.mapDeclName(_node);
 
 	// Create the procedure
@@ -1003,7 +1002,7 @@ bool ASTBoogieConverter::visit(FunctionDefinition const& _node)
 		traceabilityName = "[constructor]";
 	else if (_node.isFallback())
 		traceabilityName = "[fallback]";
-	traceabilityName = m_currentContract->name() + "::" + traceabilityName;
+	traceabilityName = m_context.currentContract()->name() + "::" + traceabilityName;
 	procDecl->addAttrs(ASTBoogieUtils::createAttrs(_node.location(), traceabilityName, *m_context.currentScanner()));
 	string funcType = _node.visibility() == Declaration::Visibility::External ? "" : " : " + _node.type()->toString();
 	m_context.addGlobalComment("\nFunction: " + _node.name() + funcType);
@@ -1384,7 +1383,7 @@ bool ASTBoogieConverter::visit(VariableDeclarationStatement const& _node)
 			bg::Expr::Ref init = convertExpression(*initialValue);
 			m_currentBlocks.top()->addStmt(bg::Stmt::comment("Packing local storage pointer " + declarations[0]->name()));
 
-			auto packed = ASTBoogieUtils::pack(initialValue, init, m_currentContract, &_node, m_context);
+			auto packed = ASTBoogieUtils::pack(initialValue, init, &_node, m_context);
 			m_localDecls.push_back(packed.ptr);
 			for (auto stmt: packed.stmts)
 				m_currentBlocks.top()->addStmt(stmt);

--- a/libsolidity/ast/ASTBoogieConverter.cpp
+++ b/libsolidity/ast/ASTBoogieConverter.cpp
@@ -1383,7 +1383,7 @@ bool ASTBoogieConverter::visit(VariableDeclarationStatement const& _node)
 			bg::Expr::Ref init = convertExpression(*initialValue);
 			m_currentBlocks.top()->addStmt(bg::Stmt::comment("Packing local storage pointer " + declarations[0]->name()));
 
-			auto packed = ASTBoogieUtils::pack(initialValue, init, m_context);
+			auto packed = ASTBoogieUtils::packToLocalPtr(initialValue, init, m_context);
 			m_localDecls.push_back(packed.ptr);
 			for (auto stmt: packed.stmts)
 				m_currentBlocks.top()->addStmt(stmt);

--- a/libsolidity/ast/ASTBoogieConverter.cpp
+++ b/libsolidity/ast/ASTBoogieConverter.cpp
@@ -502,7 +502,7 @@ bool ASTBoogieConverter::isBaseVar(bg::Expr::Ref expr)
 	if (auto exprArrSel = dynamic_pointer_cast<bg::ArrSelExpr const>(expr))
 	{
 		// Base is reached when it is a variable indexed with 'this'
-		auto idxAsId = dynamic_pointer_cast<bg::VarExpr const>(exprArrSel->getIdxs()[0]);
+		auto idxAsId = dynamic_pointer_cast<bg::VarExpr const>(exprArrSel->getIdx());
 		if (dynamic_pointer_cast<bg::VarExpr const>(exprArrSel->getBase()) &&
 				idxAsId->name() == m_context.boogieThis()->getName())
 		{
@@ -596,7 +596,7 @@ void ASTBoogieConverter::addModifiesSpecs(FunctionDefinition const& _node, bg::P
 					else
 					{
 						auto repl = replaceBaseVar(modSpec.target, expr);
-						auto write = ASTBoogieUtils::selectToUpdate(repl, modSpec.target);
+						auto write = bg::Expr::selectToUpdate(repl, modSpec.target);
 						expr = bg::Expr::if_then_else(modSpec.cond, write, expr);
 					}
 				}

--- a/libsolidity/ast/ASTBoogieConverter.h
+++ b/libsolidity/ast/ASTBoogieConverter.h
@@ -18,7 +18,6 @@ private:
 	BoogieContext& m_context;
 
 	// Helper variables to pass information between the visit methods
-	ContractDefinition const* m_currentContract;
 	FunctionDefinition const* m_currentFunc; // Function currently being processed
 	unsigned long m_currentModifier; // Index of the current modifier being processed
 

--- a/libsolidity/ast/ASTBoogieExpressionConverter.cpp
+++ b/libsolidity/ast/ASTBoogieExpressionConverter.cpp
@@ -466,54 +466,25 @@ bool ASTBoogieExpressionConverter::visit(FunctionCall const& _node)
 		auto arg = _node.arguments()[i];
 		arg->accept(*this);
 
-		// Try to get the definition (for implicit conversions)
-		FunctionDefinition const* calledFunc = nullptr;
-		if (auto exprId = dynamic_cast<Identifier const*>(&_node.expression()))
+		if (auto funcType = dynamic_cast<FunctionType const*>(_node.expression().annotation().type))
 		{
-			if (auto funcDef = dynamic_cast<FunctionDefinition const *>(exprId->annotation().referencedDeclaration))
-				calledFunc = funcDef;
-		}
-		if (auto exprMa = dynamic_cast<MemberAccess const*>(&_node.expression()))
-		{
-			if (auto funcDef = dynamic_cast<FunctionDefinition const *>(exprMa->annotation().referencedDeclaration))
-				calledFunc = funcDef;
-		}
-		// TODO: the above does not work for complex expressions like 'x.f.value(1)()'
-
-		// In bit-precise mode, we need the definition of the function to see the types of the parameters
-		// (for implicit conversions)
-		if (calledFunc && m_context.isBvEncoding())
-			m_currentExpr = ASTBoogieUtils::checkImplicitBvConversion(m_currentExpr, arg->annotation().type, calledFunc->parameters()[i]->annotation().type, m_context);
-
-		// Conversions for arrays
-		if (arg->annotation().type->category() == Type::Category::Array && arg->annotation().type->dataStoredIn(DataLocation::Storage))
-		{
-			auto arrType = dynamic_cast<ArrayType const*>(arg->annotation().type);
-			if (!arrType->isString())
+			// Check for implicit conversions
+			if (funcType->parameterTypes().size() > i && funcType->parameterTypes()[i] != arg->annotation().type &&
+					funcName != ASTBoogieUtils::BOOGIE_CALL &&
+					!boost::algorithm::starts_with(funcName, ASTBoogieUtils::VERIFIER_OLD) &&
+					!boost::algorithm::starts_with(funcName, ASTBoogieUtils::VERIFIER_SUM))
 			{
-				// Create a copy if a storage array is passed to a function
-				auto tmpDecl = m_context.tmpVar(m_context.toBoogieType(arrType->withLocation(DataLocation::Memory, false), &_node));
-				m_newDecls.push_back(tmpDecl);
-				auto memArr = m_context.getMemArray(tmpDecl->getRefTo(), m_context.toBoogieType(arrType->baseType(), &_node));
-				addSideEffect(bg::Stmt::assign(memArr, m_currentExpr));
-				m_currentExpr = tmpDecl->getRefTo();
-			}
-		}
-
-		// Conversion for local struct pointers
-		if (calledFunc && arg->annotation().type->category() == Type::Category::Struct)
-		{
-			auto argStructType = dynamic_cast<StructType const*>(arg->annotation().type);
-			auto targetStructType = dynamic_cast<StructType const*>(calledFunc->parameters()[i]->annotation().type);
-			solAssert(targetStructType, "Struct parameter type expected");
-			if (argStructType->dataStoredIn(DataLocation::Storage) && targetStructType->dataStoredIn(DataLocation::Storage) &&
-					!argStructType->isPointer() && targetStructType->isPointer())
-			{
-				auto packed = ASTBoogieUtils::packToLocalPtr(_node.arguments()[i].get(), m_currentExpr, m_context);
-				m_newDecls.push_back(packed.ptr);
-				for (auto stmt: packed.stmts)
+				// Introduce temp variable, make the assignment, including conversions
+				auto argDecl = m_context.tmpVar(m_context.toBoogieType(funcType->parameterTypes()[i], arg.get()), "call_arg");
+				m_newDecls.push_back(argDecl);
+				auto ar = ASTBoogieUtils::makeAssign(
+						ASTBoogieUtils::AssignParam{argDecl->getRefTo(), funcType->parameterTypes()[i], nullptr },
+						ASTBoogieUtils::AssignParam{m_currentExpr, arg->annotation().type, arg.get() },
+						Token::Assign, &_node, m_context);
+				m_newDecls.insert(m_newDecls.end(), ar.newDecls.begin(), ar.newDecls.end());
+				for (auto stmt: ar.newStmts)
 					addSideEffect(stmt);
-				m_currentExpr = packed.ptr->getRefTo();
+				m_currentExpr = argDecl->getRefTo();
 			}
 		}
 

--- a/libsolidity/ast/ASTBoogieExpressionConverter.cpp
+++ b/libsolidity/ast/ASTBoogieExpressionConverter.cpp
@@ -509,7 +509,7 @@ bool ASTBoogieExpressionConverter::visit(FunctionCall const& _node)
 			if (argStructType->dataStoredIn(DataLocation::Storage) && targetStructType->dataStoredIn(DataLocation::Storage) &&
 					!argStructType->isPointer() && targetStructType->isPointer())
 			{
-				auto packed = ASTBoogieUtils::pack(_node.arguments()[i].get(), m_currentExpr, &_node, m_context);
+				auto packed = ASTBoogieUtils::pack(_node.arguments()[i].get(), m_currentExpr, m_context);
 				m_newDecls.push_back(packed.ptr);
 				for (auto stmt: packed.stmts)
 					addSideEffect(stmt);

--- a/libsolidity/ast/ASTBoogieExpressionConverter.cpp
+++ b/libsolidity/ast/ASTBoogieExpressionConverter.cpp
@@ -509,7 +509,7 @@ bool ASTBoogieExpressionConverter::visit(FunctionCall const& _node)
 			if (argStructType->dataStoredIn(DataLocation::Storage) && targetStructType->dataStoredIn(DataLocation::Storage) &&
 					!argStructType->isPointer() && targetStructType->isPointer())
 			{
-				auto packed = ASTBoogieUtils::pack(_node.arguments()[i].get(), m_currentExpr, m_context);
+				auto packed = ASTBoogieUtils::packToLocalPtr(_node.arguments()[i].get(), m_currentExpr, m_context);
 				m_newDecls.push_back(packed.ptr);
 				for (auto stmt: packed.stmts)
 					addSideEffect(stmt);
@@ -1107,7 +1107,7 @@ bool ASTBoogieExpressionConverter::visit(MemberAccess const& _node)
 			// Local pointers: unpack first
 			if (structType->dataStoredIn(DataLocation::Storage) && structType->isPointer())
 				if (auto id = dynamic_cast<Identifier const*>(&_node.expression()))
-					m_currentAddress = ASTBoogieUtils::unpack(id, m_context);
+					m_currentAddress = ASTBoogieUtils::unpackLocalPtr(id, m_context);
 
 			m_currentExpr = bg::Expr::dtsel(m_currentAddress,
 					m_context.mapDeclName(*_node.annotation().referencedDeclaration),

--- a/libsolidity/ast/ASTBoogieExpressionConverter.h
+++ b/libsolidity/ast/ASTBoogieExpressionConverter.h
@@ -17,7 +17,6 @@ class ASTBoogieExpressionConverter : private ASTConstVisitor
 private:
 
 	BoogieContext& m_context;
-	ContractDefinition const* m_currentContract;
 
 	// Helper variables to pass information between the visit methods
 	boogie::Expr::Ref m_currentExpr;
@@ -84,7 +83,7 @@ public:
 	/**
 	 * Create a new instance with a given context and an optional location used for reporting errors.
 	 */
-	ASTBoogieExpressionConverter(BoogieContext& context, ContractDefinition const* currentContract);
+	ASTBoogieExpressionConverter(BoogieContext& context);
 
 	/**
 	 * Convert a Solidity Expression into a Boogie expression. As a side effect, the conversion might

--- a/libsolidity/ast/ASTBoogieExpressionConverter.h
+++ b/libsolidity/ast/ASTBoogieExpressionConverter.h
@@ -18,7 +18,6 @@ private:
 
 	BoogieContext& m_context;
 	ContractDefinition const* m_currentContract;
-	ASTNode const* m_currentScope;
 
 	// Helper variables to pass information between the visit methods
 	boogie::Expr::Ref m_currentExpr;
@@ -85,7 +84,7 @@ public:
 	/**
 	 * Create a new instance with a given context and an optional location used for reporting errors.
 	 */
-	ASTBoogieExpressionConverter(BoogieContext& context, ContractDefinition const* currentContract, ASTNode const* currentScope);
+	ASTBoogieExpressionConverter(BoogieContext& context, ContractDefinition const* currentContract);
 
 	/**
 	 * Convert a Solidity Expression into a Boogie expression. As a side effect, the conversion might

--- a/libsolidity/ast/ASTBoogieStats.cpp
+++ b/libsolidity/ast/ASTBoogieStats.cpp
@@ -19,6 +19,21 @@ bool ASTBoogieStats::hasDocTag(DocumentedAnnotation const& _annot, std::string _
 	return false;
 }
 
+bool ASTBoogieStats::visit(ContractDefinition const& _node)
+{
+	for (auto cn: _node.annotation().linearizedBaseContracts)
+	{
+		for (auto structDef: cn->definedStructs())
+		{
+			if (m_contractsForStructs.find(structDef) == m_contractsForStructs.end())
+				m_contractsForStructs[structDef] = {};
+
+			m_contractsForStructs[structDef].push_back(&_node);
+		}
+	}
+	return true;
+}
+
 bool ASTBoogieStats::visit(FunctionDefinition const& _node)
 {
 	if (!m_hasModifiesSpecs)

--- a/libsolidity/ast/ASTBoogieStats.h
+++ b/libsolidity/ast/ASTBoogieStats.h
@@ -14,12 +14,16 @@ class ASTBoogieStats : public ASTConstVisitor
 private:
 	bool m_hasModifiesSpecs;
 
+	std::map<StructDefinition const*, std::list<ContractDefinition const*>> m_contractsForStructs;
+
 	bool hasDocTag(DocumentedAnnotation const& _annot, std::string _tag) const;
 
 public:
 	ASTBoogieStats() : m_hasModifiesSpecs(false) {}
 	bool hasModifiesSpecs() const { return m_hasModifiesSpecs; }
+	std::list<ContractDefinition const*> contractsForStruct(StructDefinition const* structDef) { return m_contractsForStructs[structDef]; }
 
+	bool visit(ContractDefinition const& _node) override;
 	bool visit(FunctionDefinition const& _node) override;
 };
 

--- a/libsolidity/ast/ASTBoogieUtils.cpp
+++ b/libsolidity/ast/ASTBoogieUtils.cpp
@@ -1286,7 +1286,7 @@ void ASTBoogieUtils::packInternal(Expression const* expr, bg::Expr::Ref bgExpr, 
 	// Function calls return pointers, no need to pack, just copy the return value
 	if (dynamic_cast<FunctionCall const*>(expr))
 	{
-		auto ptr = context.tmpVar(ASTBoogieUtils::mappingType(context.intType(256), context.intType(256)));
+		auto ptr = context.tmpVar(context.localPtrType());
 		result.ptr = ptr;
 		result.stmts.push_back(bg::Stmt::assign(ptr->getRefTo(), bgExpr));
 		return;
@@ -1294,7 +1294,7 @@ void ASTBoogieUtils::packInternal(Expression const* expr, bg::Expr::Ref bgExpr, 
 	// Identifier: search for matching state variable in the contract
 	if (auto idExpr = dynamic_cast<Identifier const*>(expr))
 	{
-		auto ptr = context.tmpVar(ASTBoogieUtils::mappingType(context.intType(256), context.intType(256)));
+		auto ptr = context.tmpVar(context.localPtrType());
 		auto vars = ASTNode::filteredNodes<VariableDeclaration>(context.currentContract()->subNodes());
 		for (unsigned i = 0; i < vars.size(); ++i)
 		{

--- a/libsolidity/ast/ASTBoogieUtils.cpp
+++ b/libsolidity/ast/ASTBoogieUtils.cpp
@@ -1426,7 +1426,7 @@ bg::Expr::Ref ASTBoogieUtils::unpackInternal(Identifier const* id, Declaration c
 	//   ite(arr[1] == 0, s1.t1, s1.ts[arr[2]], ... )))
 
 	// Contract: go through state vars and create conditional expression recursively
-	if (auto contrDef = dynamic_cast<ContractDefinition const*>(decl))
+	if (dynamic_cast<ContractDefinition const*>(decl))
 	{
 		auto structType = dynamic_cast<StructType const*>(id->annotation().type);
 		solAssert(structType, "Expected struct type when unpacking");

--- a/libsolidity/ast/ASTBoogieUtils.cpp
+++ b/libsolidity/ast/ASTBoogieUtils.cpp
@@ -1376,7 +1376,8 @@ void ASTBoogieUtils::packInternal(Expression const* expr, bg::Expr::Ref bgExpr, 
 bg::Expr::Ref ASTBoogieUtils::unpackLocalPtr(Identifier const* id, BoogieContext& context)
 {
 	auto expr = unpackInternal(id, context.currentContract(), 0, nullptr, context);
-	solAssert(expr, "Nothing to unpack");
+	if (!expr)
+		context.reportError(id, "Nothing to unpack, perhaps there are no instances of the type");
 	return expr;
 }
 
@@ -1403,7 +1404,8 @@ bg::Expr::Ref ASTBoogieUtils::unpackInternal(Identifier const* id, Declaration c
 							subExpr, unpackedExpr);
 			}
 		}
-		solAssert(unpackedExpr, "Nothing to unpack");
+		if (!unpackedExpr)
+			context.reportError(id, "Nothing to unpack, perhaps there are no instances of the type");
 		return unpackedExpr;
 	}
 	// Variable (state var or struct member)

--- a/libsolidity/ast/ASTBoogieUtils.h
+++ b/libsolidity/ast/ASTBoogieUtils.h
@@ -233,6 +233,13 @@ public:
 	static
 	boogie::Expr::Ref unpack(Identifier const* id, BoogieContext& context);
 
+private:
+	static
+	void packInternal(Expression const* expr, boogie::Expr::Ref bgExpr, ASTNode const* assocNode, BoogieContext& context, PackResult& result);
+
+	static
+	boogie::Expr::Ref unpackInternal(Identifier const* id, Declaration const* decl, int depth, boogie::Expr::Ref base, BoogieContext& context);
+
 };
 
 }

--- a/libsolidity/ast/ASTBoogieUtils.h
+++ b/libsolidity/ast/ASTBoogieUtils.h
@@ -241,8 +241,8 @@ public:
 
 private:
 	/**
-	 * Packs a path to a local storage into an array. E.g., 'ss[5].t' becomes [i, 5, j] if
-	 *  'ss' is the ith state var and 't' is the jth member.
+	 * Packs a path to a local storage into an array. E.g., 'ss[i].t' becomes [2, i, 3] if
+	 *  'ss' is the 2nd state var and 't' is the 3rd member.
 	 */
 	static
 	void packInternal(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context, PackResult& result);

--- a/libsolidity/ast/ASTBoogieUtils.h
+++ b/libsolidity/ast/ASTBoogieUtils.h
@@ -235,14 +235,18 @@ private:
 				ASTNode const* assocNode, BoogieContext& context, AssignResult& result);
 
 public:
-	struct FreezeResult {
-		boogie::Expr::Ref expr;
-		std::list<boogie::Decl::Ref> newDecls;
+	struct PackResult {
+		boogie::Decl::Ref ptr;
 		std::list<boogie::Stmt::Ref> stmts;
 	};
 
 	static
-	FreezeResult freeze(boogie::Expr::Ref bgExpr, Expression const* expr, ASTNode const* assocNode, BoogieContext& context);
+	PackResult pack(Expression const* expr, boogie::Expr::Ref bgExpr, ContractDefinition const* currentContract,
+			ASTNode const* assocNode, BoogieContext& context);
+
+	static
+	boogie::Expr::Ref unpack(Identifier const* id, ContractDefinition const* currentContract, BoogieContext& context);
+
 };
 
 }

--- a/libsolidity/ast/ASTBoogieUtils.h
+++ b/libsolidity/ast/ASTBoogieUtils.h
@@ -228,11 +228,10 @@ public:
 	};
 
 	static
-	PackResult pack(Expression const* expr, boogie::Expr::Ref bgExpr, ContractDefinition const* currentContract,
-			ASTNode const* assocNode, BoogieContext& context);
+	PackResult pack(Expression const* expr, boogie::Expr::Ref bgExpr, ASTNode const* assocNode, BoogieContext& context);
 
 	static
-	boogie::Expr::Ref unpack(Identifier const* id, ContractDefinition const* currentContract, BoogieContext& context);
+	boogie::Expr::Ref unpack(Identifier const* id, BoogieContext& context);
 
 };
 

--- a/libsolidity/ast/ASTBoogieUtils.h
+++ b/libsolidity/ast/ASTBoogieUtils.h
@@ -165,19 +165,6 @@ public:
 	bool isStateVar(Declaration const *decl);
 
 	/**
-	 * Recursively translate a select expression to an update
-	 */
-	static
-	boogie::Expr::Ref selectToUpdate(boogie::Expr::Ref sel, boogie::Expr::Ref value);
-
-	/**
-	 * Recursively translate a select expression to an update and assign
-	 * it to the base expression
-	 */
-	static
-	boogie::Stmt::Ref selectToUpdateStmt(boogie::Expr::Ref sel, boogie::Expr::Ref value);
-
-	/**
 	 * Helper method to give a default value for a type.
 	 */
 	static

--- a/libsolidity/ast/ASTBoogieUtils.h
+++ b/libsolidity/ast/ASTBoogieUtils.h
@@ -245,7 +245,7 @@ private:
 	 *  'ss' is the 2nd state var and 't' is the 3rd member.
 	 */
 	static
-	void packInternal(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context, PackResult& result);
+	void packInternal(Expression const* expr, boogie::Expr::Ref bgExpr, StructType const* structType, BoogieContext& context, PackResult& result);
 
 	/**
 	 * Unpacks an array into a tree of paths (conditional) to local storage (opposite of packing).

--- a/libsolidity/ast/ASTBoogieUtils.h
+++ b/libsolidity/ast/ASTBoogieUtils.h
@@ -228,14 +228,14 @@ public:
 	};
 
 	static
-	PackResult pack(Expression const* expr, boogie::Expr::Ref bgExpr, ASTNode const* assocNode, BoogieContext& context);
+	PackResult pack(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context);
 
 	static
 	boogie::Expr::Ref unpack(Identifier const* id, BoogieContext& context);
 
 private:
 	static
-	void packInternal(Expression const* expr, boogie::Expr::Ref bgExpr, ASTNode const* assocNode, BoogieContext& context, PackResult& result);
+	void packInternal(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context, PackResult& result);
 
 	static
 	boogie::Expr::Ref unpackInternal(Identifier const* id, Declaration const* decl, int depth, boogie::Expr::Ref base, BoogieContext& context);

--- a/libsolidity/ast/ASTBoogieUtils.h
+++ b/libsolidity/ast/ASTBoogieUtils.h
@@ -227,16 +227,30 @@ public:
 		std::list<boogie::Stmt::Ref> stmts;
 	};
 
+	/**
+	 * Pack an expression into a local storage pointer
+	 */
 	static
-	PackResult pack(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context);
+	PackResult packToLocalPtr(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context);
 
+	/**
+	 * Unpack a local storage pointer into an access to storage
+	 */
 	static
-	boogie::Expr::Ref unpack(Identifier const* id, BoogieContext& context);
+	boogie::Expr::Ref unpackLocalPtr(Identifier const* id, BoogieContext& context);
 
 private:
+	/**
+	 * Packs a path to a local storage into an array. E.g., 'ss[5].t' becomes [i, 5, j] if
+	 *  'ss' is the ith state var and 't' is the jth member.
+	 */
 	static
 	void packInternal(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context, PackResult& result);
 
+	/**
+	 * Unpacks an array into a tree of paths (conditional) to local storage (opposite of packing).
+	 * E.g., ite(arr[0] == 0, statevar1, ite(arr[0] == 1, statevar2, ...
+	 */
 	static
 	boogie::Expr::Ref unpackInternal(Identifier const* id, Declaration const* decl, int depth, boogie::Expr::Ref base, BoogieContext& context);
 

--- a/libsolidity/ast/BoogieAst.cpp
+++ b/libsolidity/ast/BoogieAst.cpp
@@ -281,6 +281,10 @@ Stmt::Ref Stmt::assert_(Expr::Ref e, std::vector<Attr::Ref> const& attrs)
 
 Stmt::Ref Stmt::assign(Expr::Ref e, Expr::Ref f)
 {
+	if (auto cond = std::dynamic_pointer_cast<CondExpr const>(e))
+		return Stmt::ifelse(cond->getCond(),
+				Block::block("", {Stmt::assign(cond->getThen(), f)}),
+				Block::block("", {Stmt::assign(cond->getElse(), f)}));
 	return std::make_shared<AssignStmt const>(std::vector<Expr::Ref>{e}, std::vector<Expr::Ref>{f});
 }
 

--- a/libsolidity/ast/BoogieAst.h
+++ b/libsolidity/ast/BoogieAst.h
@@ -73,14 +73,14 @@ public:
 	static Ref not_(Ref e);
 	static Ref neg(Ref e);
 	static Ref arrsel(Ref b, Ref i);
-	static Ref arrsel(Ref a, std::vector<Ref> const& i);
 	static Ref arrupd(Ref b, Ref i, Ref v);
-	static Ref arrupd(Ref a, std::vector<Ref> const& i, Ref v);
 	static Ref dtsel(Ref b, std::string mem, FuncDeclRef constr, DataTypeDeclRef dt);
 	static Ref dtupd(Ref b, std::string mem, Ref v, FuncDeclRef constr, DataTypeDeclRef dt);
 	static Ref if_then_else(Ref c, Ref t, Ref e);
 	static Ref old(Ref expr);
 	static Ref tuple(std::vector<Ref> const& e);
+
+	static Ref selectToUpdate(Ref sel, Ref value);
 };
 
 struct Binding
@@ -224,23 +224,20 @@ public:
 };
 
 class ArrSelExpr : public SelExpr {
-	std::vector<Ref> idxs;
+	Ref idx;
 public:
-	ArrSelExpr(Ref a, std::vector<Ref> const& i) : SelExpr(a), idxs(i) {}
-	ArrSelExpr(Ref a, Ref i) : SelExpr(a), idxs(std::vector<Ref>(1, i)) {}
-	std::vector<Ref> const& getIdxs() const { return idxs; }
+	ArrSelExpr(Ref a, Ref i) : SelExpr(a), idx(i) {}
+	Ref const& getIdx() const { return idx; }
 	void print(std::ostream& os) const override;
-	Ref toUpdate(Ref v) const override { return Expr::arrupd(base, idxs, v); }
-	Ref replaceBase(Ref b) const override { return Expr::arrsel(b, idxs); }
+	Ref toUpdate(Ref v) const override { return Expr::arrupd(base, idx, v); }
+	Ref replaceBase(Ref b) const override { return Expr::arrsel(b, idx); }
 };
 
 class ArrUpdExpr : public UpdExpr {
-	std::vector<Ref> idxs;
+	Ref idx;
 public:
-	ArrUpdExpr(Ref a, std::vector<Ref> const& i, Expr::Ref v)
-		: UpdExpr(a, v), idxs(i) {}
 	ArrUpdExpr(Ref a, Ref i, Ref v)
-		: UpdExpr(a, v), idxs(std::vector<Ref>(1, i)) {}
+		: UpdExpr(a, v), idx(i) {}
 	void print(std::ostream& os) const override;
 };
 
@@ -326,7 +323,6 @@ public:
 	static Ref assert_(Expr::Ref e,
 		std::vector<Attr::Ref> const& attrs = {});
 	static Ref assign(Expr::Ref e, Expr::Ref f);
-	static Ref assign(std::vector<Expr::Ref> const& lhs, std::vector<Expr::Ref> const& rhs);
 	static Ref assume(Expr::Ref e);
 	static Ref assume(Expr::Ref e, Attr::Ref attr);
 	static Ref call(

--- a/libsolidity/ast/BoogieAst.h
+++ b/libsolidity/ast/BoogieAst.h
@@ -114,6 +114,10 @@ public:
 	CondExpr(Expr::Ref c, Expr::Ref t, Expr::Ref e)
 		: cond(c), then(t), else_(e) {}
 	void print(std::ostream& os) const override;
+
+	Expr::Ref getCond() const { return cond; }
+	Expr::Ref getThen() const { return then; }
+	Expr::Ref getElse() const { return else_; }
 };
 
 class FunExpr : public Expr {

--- a/libsolidity/ast/BoogieContext.cpp
+++ b/libsolidity/ast/BoogieContext.cpp
@@ -278,7 +278,6 @@ bg::TypeDeclRef BoogieContext::getStructType(StructDefinition const* structDef, 
 			}
 			m_storStructTypes[structDef] = bg::Decl::datatype(typeName, members);
 			addDecl(m_storStructTypes[structDef]);
-			getStructConstructor(structDef);
 		}
 		return m_storStructTypes[structDef];
 	}

--- a/libsolidity/ast/BoogieContext.cpp
+++ b/libsolidity/ast/BoogieContext.cpp
@@ -49,9 +49,11 @@ BoogieContext::BoogieContext(Encoding encoding,
 		ErrorReporter* errorReporter,
 		std::map<ASTNode const*,
 		std::shared_ptr<DeclarationContainer>> scopes,
-		EVMVersion evmVersion)
+		EVMVersion evmVersion,
+		ASTBoogieStats stats)
 :
-		m_program(), m_encoding(encoding), m_overflow(overflow), m_modAnalysis(modAnalysis), m_errorReporter(errorReporter),
+		m_stats(stats), m_program(), m_encoding(encoding), m_overflow(overflow),
+		m_modAnalysis(modAnalysis), m_errorReporter(errorReporter),
 		m_currentScanner(nullptr), m_scopes(scopes), m_evmVersion(evmVersion),
 		m_currentContractInvars(), m_currentSumDecls(), m_builtinFunctions(),
 		m_transferIncluded(false), m_callIncluded(false), m_sendIncluded(false)

--- a/libsolidity/ast/BoogieContext.cpp
+++ b/libsolidity/ast/BoogieContext.cpp
@@ -386,8 +386,10 @@ bg::TypeDeclRef BoogieContext::toBoogieType(TypePointer tp, ASTNode const* _asso
 	case Type::Category::Struct:
 	{
 		auto structTp = dynamic_cast<StructType const*>(tp);
+		// Local pointers are arrays
 		if (structTp->location() == DataLocation::Storage && structTp->isPointer())
-			reportError(_associatedNode, "Local storage pointers are not supported");
+			return ASTBoogieUtils::mappingType(intType(256), intType(256));
+
 		return getStructType(&structTp->structDefinition(), structTp->location());
 	}
 	case Type::Category::Enum:

--- a/libsolidity/ast/BoogieContext.cpp
+++ b/libsolidity/ast/BoogieContext.cpp
@@ -222,6 +222,11 @@ bg::TypeDeclRef BoogieContext::intType(unsigned size) const
 		return bg::Decl::typee("int");
 }
 
+bg::TypeDeclRef BoogieContext::localPtrType()
+{
+	return ASTBoogieUtils::mappingType(intType(256), intType(256));
+}
+
 bg::FuncDeclRef BoogieContext::getStructConstructor(StructDefinition const* structDef)
 {
 	if (m_storStructConstrs.find(structDef) == m_storStructConstrs.end())

--- a/libsolidity/ast/BoogieContext.h
+++ b/libsolidity/ast/BoogieContext.h
@@ -6,6 +6,7 @@
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/analysis/GlobalContext.h>
 #include <libsolidity/analysis/DeclarationContainer.h>
+#include <libsolidity/ast/ASTBoogieStats.h>
 #include <libsolidity/ast/BoogieAst.h>
 #include <set>
 
@@ -59,6 +60,7 @@ public:
 
 private:
 
+	ASTBoogieStats m_stats;
 	boogie::Program m_program; // Result of the conversion is a single Boogie program (top-level node)
 	std::map<std::string, boogie::Decl::Ref> m_stringLiterals;
 	std::map<std::string, boogie::Decl::Ref> m_addressLiterals;
@@ -110,8 +112,10 @@ public:
 			bool modAnalysis,
 			langutil::ErrorReporter* errorReporter,
 			std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>> scopes,
-			langutil::EVMVersion evmVersion);
+			langutil::EVMVersion evmVersion,
+			ASTBoogieStats stats);
 
+	ASTBoogieStats& stats() { return m_stats; }
 	Encoding encoding() const { return m_encoding; }
 	bool isBvEncoding() const { return m_encoding == Encoding::BV; }
 	bool overflow() const { return m_overflow; }

--- a/libsolidity/ast/BoogieContext.h
+++ b/libsolidity/ast/BoogieContext.h
@@ -69,7 +69,6 @@ private:
 	std::map<StructDefinition const*,boogie::TypeDeclRef> m_memStructTypes;
 	std::map<StructDefinition const*,boogie::TypeDeclRef> m_storStructTypes;
 	std::map<StructDefinition const*,boogie::FuncDeclRef> m_storStructConstrs;
-	std::map<Declaration const*, boogie::Expr::Ref> m_localPtrs;
 
 	std::map<std::string,boogie::DataTypeDeclRef> m_arrDataTypes;
 	std::map<std::string,boogie::FuncDeclRef> m_arrConstrs;
@@ -159,8 +158,6 @@ public:
 
 	boogie::FuncDeclRef getStructConstructor(StructDefinition const* structDef);
 	boogie::TypeDeclRef getStructType(StructDefinition const* structDef, DataLocation loc);
-
-	std::map<Declaration const*, boogie::Expr::Ref>& localPtrs() { return m_localPtrs; }
 
 	boogie::Expr::Ref getMemArray(boogie::Expr::Ref arrPtrExpr, boogie::TypeDeclRef type) { return boogie::Expr::arrsel(m_memArrs[type->getName()]->getRefTo(), arrPtrExpr); }
 	boogie::Expr::Ref getArrayLength(boogie::Expr::Ref arrayExpr, boogie::TypeDeclRef type) { return boogie::Expr::dtsel(arrayExpr, "length", m_arrConstrs[type->getName()], m_arrDataTypes[type->getName()]); }

--- a/libsolidity/ast/BoogieContext.h
+++ b/libsolidity/ast/BoogieContext.h
@@ -162,6 +162,8 @@ public:
 	/** Returns the integer type corresponding to the encoding */
 	boogie::TypeDeclRef intType(unsigned size) const;
 
+	boogie::TypeDeclRef localPtrType();
+
 	boogie::FuncDeclRef getStructConstructor(StructDefinition const* structDef);
 	boogie::TypeDeclRef getStructType(StructDefinition const* structDef, DataLocation loc);
 

--- a/libsolidity/ast/BoogieContext.h
+++ b/libsolidity/ast/BoogieContext.h
@@ -86,6 +86,7 @@ private:
 	std::map<ASTNode const*, std::shared_ptr<DeclarationContainer>> m_scopes;
 	langutil::EVMVersion m_evmVersion;
 
+	ContractDefinition const* m_currentContract;
 	std::list<DocTagExpr> m_currentContractInvars; // Invariants for the current contract (in Boogie and original format)
 	std::map<Declaration const*, TypePointer> m_currentSumDecls; // List of declarations that need shadow variable to sum
 
@@ -124,6 +125,8 @@ public:
 	std::map<Declaration const*, TypePointer>& currentSumDecls() { return m_currentSumDecls; }
 	int nextId() { return m_nextId++; }
 	boogie::VarDeclRef tmpVar(boogie::TypeDeclRef type, std::string prefix = "tmp");
+	ContractDefinition const* currentContract() const { return m_currentContract; }
+	void setCurrentContract(ContractDefinition const* contract) { m_currentContract = contract; }
 	/**
 	 * Map a declaration name to a name in Boogie
 	 */

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1247,7 +1247,7 @@ void CommandLineInterface::handleBoogie()
 
 	BoogieContext context(encoding, overflow,
 			m_args.count(g_strAstBoogieModAnalysis) || stats.hasModifiesSpecs(),
-			&errorReporter, m_compiler->getScopes(), m_evmVersion);
+			&errorReporter, m_compiler->getScopes(), m_evmVersion, stats);
 	ASTBoogieConverter boogieConverter(context);
 
 	SourceReferenceFormatter formatter(serr(false));

--- a/test/solc-verify/LocalStorageSpec.sol
+++ b/test/solc-verify/LocalStorageSpec.sol
@@ -1,0 +1,30 @@
+pragma solidity >=0.5.0;
+
+contract A {
+  struct S {
+      int x;
+  }
+  function setA0(S storage s_ptr) internal {
+    s_ptr.x = 0;
+  }
+}
+
+contract B is A {
+  S s;
+  /// @notice postcondition s.x == 0
+  function setB0(S storage s_ptr) internal {
+    setA0(s_ptr);
+  }
+}
+
+contract C is B {
+  S s;
+  function setC0(S storage s_ptr) internal {
+    setB0(s_ptr);
+  }
+  function() external payable {
+    setC0(s);
+    assert(s.x == 0);
+  }
+
+}

--- a/test/solc-verify/LocalStorageSpec.sol
+++ b/test/solc-verify/LocalStorageSpec.sol
@@ -17,7 +17,7 @@ contract B is A {
   }
 }
 
-contract C is B {
+contract LocalStorageSpec is B {
   S s;
   function setC0(S storage s_ptr) internal {
     setB0(s_ptr);

--- a/test/solc-verify/StructsCopying.sol
+++ b/test/solc-verify/StructsCopying.sol
@@ -117,7 +117,7 @@ contract StructsCopying {
         s1.x = 1;
         S storage sl1 = s1;
         S memory sm = S(3);
-        sm = s1; // Deep copy
+        sm = sl1; // Deep copy
         assert(sl1.x == 1);
         assert(sm.x == 1);
         sl1.x = 2;

--- a/test/solc-verify/StructsLocalStorage.sol
+++ b/test/solc-verify/StructsLocalStorage.sol
@@ -11,6 +11,7 @@ contract StructsLocalStorage {
     }
 
     S ss;
+    S ss2;
 
     function testSimple() public {
         ss.x = 1;
@@ -19,127 +20,21 @@ contract StructsLocalStorage {
         assert(ss.t.z == 2);
 
         S storage sl = ss;
+        assert(sl.x == 1);
+        assert(sl.t.z == 2);
 
-        sl.x = 3;
-        sl.t.z = 4;
-        assert(ss.x == 3);
-        assert(ss.t.z == 4);
-    }
+        ss.x = 3;
+        ss.t.z = 4;
+        assert(sl.x == 3);
+        assert(sl.t.z == 4);
 
-    function testMember() public {
-        ss.x = 1;
-        ss.t.z = 2;
-        assert(ss.x == 1);
-        assert(ss.t.z == 2);
-
-        T storage tl = ss.t;
-        tl.z = 3;
-
-        assert(ss.x == 1);
-        assert(ss.t.z == 3);
-    }
-
-    mapping(uint=>S) s_map;
-
-    function testMapping() public {
-        s_map[0].x = 1;
-        s_map[0].t.z = 2;
-        s_map[1].x = 3;
-        s_map[1].t.z = 4;
-
-        uint i = 0;
-        S storage sl = s_map[i];
-        i = i + 1;
         sl.x = 5;
         sl.t.z = 6;
-        assert(s_map[0].x == 5);
-        assert(s_map[0].t.z == 6);
-        assert(s_map[1].x == 3);
-        assert(s_map[1].t.z == 4);
-    }
-
-    function testMappingMember() public {
-        s_map[0].x = 1;
-        s_map[0].t.z = 2;
-        s_map[1].x = 3;
-        s_map[1].t.z = 4;
-
-        uint i = 0;
-        T storage tl = s_map[i].t;
-        i = i + 1;
-        tl.z = 5;
-        assert(s_map[0].x == 1);
-        assert(s_map[0].t.z == 5);
-        assert(s_map[1].x == 3);
-        assert(s_map[1].t.z == 4);
-    }
-
-    S[2] s_arr;
-
-    function testArray() public {
-        s_arr[0].x = 1;
-        s_arr[0].t.z = 2;
-        s_arr[1].x = 3;
-        s_arr[1].t.z = 4;
-
-        uint i = 0;
-        S storage sl = s_arr[i];
-        i = i + 1;
-        sl.x = 5;
-        sl.t.z = 6;
-        assert(s_arr[0].x == 5);
-        assert(s_arr[0].t.z == 6);
-        assert(s_arr[1].x == 3);
-        assert(s_arr[1].t.z == 4);
-    }
-
-    function testArrayMember() public {
-        s_arr[0].x = 1;
-        s_arr[0].t.z = 2;
-        s_arr[1].x = 3;
-        s_arr[1].t.z = 4;
-
-        uint i = 0;
-        T storage tl = s_arr[i].t;
-        i = i + 1;
-        tl.z = 5;
-        assert(s_arr[0].x == 1);
-        assert(s_arr[0].t.z == 5);
-        assert(s_arr[1].x == 3);
-        assert(s_arr[1].t.z == 4);
-    }
-
-    T[2] t_arr;
-
-    function testReassign() public {
-        t_arr[0].z = 1;
-        t_arr[1].z = 2;
-        assert(t_arr[0].z == 1);
-        assert(t_arr[1].z == 2);
-
-        uint i = 0;
-        T storage tl = t_arr[i];
-        i++;
-        tl.z = 3;
-        assert(t_arr[0].z == 3);
-        assert(t_arr[1].z == 2);
-
-        tl = t_arr[i]; // Reassign
-        assert(t_arr[0].z == 3);
-        assert(t_arr[1].z == 2);
-
-        tl.z = 4;
-        assert(t_arr[0].z == 3);
-        assert(t_arr[1].z == 4);
+        assert(ss.x == 5);
+        assert(ss.t.z == 6);
     }
 
     function() external payable {
         testSimple();
-        testMember();
-        testMapping();
-        testMappingMember();
-        testArray();
-        testArrayMember();
-        testReassign();
     }
 }

--- a/test/solc-verify/StructsLocalStorage.sol
+++ b/test/solc-verify/StructsLocalStorage.sol
@@ -131,6 +131,20 @@ contract StructsLocalStorage {
         assert(t_arr[1].z == 4);
     }
 
+    struct U {
+        T[5] tt;
+    }
+
+    U[5] uu;
+
+    function testAlternatingNesting() public {
+        uu[1].tt[2].z = 12;
+        uu[2].tt[1].z = 21;
+
+        T storage tl = uu[1].tt[2];
+        assert(tl.z == 12);
+    }
+
     function() external payable {
         testSimple();
         testMember();
@@ -139,5 +153,6 @@ contract StructsLocalStorage {
         testArray();
         testArrayMember();
         testReassign();
+        testAlternatingNesting();
     }
 }

--- a/test/solc-verify/StructsLocalStorage.sol
+++ b/test/solc-verify/StructsLocalStorage.sol
@@ -145,6 +145,25 @@ contract StructsLocalStorage {
         assert(tl.z == 12);
     }
 
+    mapping(uint=>S) s_map;
+
+    function testMapping() public {
+        s_map[0].x = 1;
+        s_map[0].t.z = 2;
+        s_map[1].x = 3;
+        s_map[1].t.z = 4;
+
+        uint i = 0;
+        S storage sl = s_map[i];
+        i = i + 1;
+        sl.x = 5;
+        sl.t.z = 6;
+        assert(s_map[0].x == 5);
+        assert(s_map[0].t.z == 6);
+        assert(s_map[1].x == 3);
+        assert(s_map[1].t.z == 4);
+    }
+
     function() external payable {
         testSimple();
         testMember();
@@ -154,5 +173,6 @@ contract StructsLocalStorage {
         testArrayMember();
         testReassign();
         testAlternatingNesting();
+        testMapping();
     }
 }

--- a/test/solc-verify/StructsLocalStorage.sol
+++ b/test/solc-verify/StructsLocalStorage.sol
@@ -11,54 +11,71 @@ contract StructsLocalStorage {
     }
 
     T t1;
-    S ss;
+    S s1;
+    S s2;
 
     function testSimple() public {
-        ss.x = 1;
-        ss.t.z = 2;
-        assert(ss.x == 1);
-        assert(ss.t.z == 2);
+        s1.x = 1;
+        s1.t.z = 2;
+        assert(s1.x == 1);
+        assert(s1.t.z == 2);
 
-        S storage sl = ss;
+        S storage sl = s1;
         assert(sl.x == 1);
         assert(sl.t.z == 2);
 
-        ss.x = 3;
-        ss.t.z = 4;
+        s1.x = 3;
+        s1.t.z = 4;
         assert(sl.x == 3);
         assert(sl.t.z == 4);
 
         sl.x = 5;
         sl.t.z = 6;
-        assert(ss.x == 5);
-        assert(ss.t.z == 6);
+        assert(s1.x == 5);
+        assert(s1.t.z == 6);
     }
 
     function testMember() public {
-        ss.x = 1;
-        ss.t.z = 2;
+        s1.x = 1;
+        s1.t.z = 2;
         t1.z = 3;
-        assert(ss.x == 1);
-        assert(ss.t.z == 2);
+        assert(s1.x == 1);
+        assert(s1.t.z == 2);
         assert(t1.z == 3);
 
-        T storage tl = ss.t;
+        T storage tl = s1.t;
         tl.z = 4;
 
-        assert(ss.x == 1);
-        assert(ss.t.z == 4);
+        assert(s1.x == 1);
+        assert(s1.t.z == 4);
         assert(t1.z == 3);
 
         tl = t1;
         tl.z = 5;
 
-        assert(ss.x == 1);
-        assert(ss.t.z == 4);
+        assert(s1.x == 1);
+        assert(s1.t.z == 4);
         assert(t1.z == 5);
+    }
+
+    function testConditional(bool b) public {
+        // Set three members to 1
+        t1.z = 1;
+        s1.t.z = 1;
+        s2.t.z = 1;
+        // Conditionally point to one of the first two
+        T storage ptr = t1;
+        if (b) ptr = s1.t;
+        ptr.z = 2; // Change
+
+        // The third one should not change regardless condition
+        assert(s2.t.z == 1);
     }
 
     function() external payable {
         testSimple();
         testMember();
+        testConditional(true);
+        testConditional(false);
     }
 }

--- a/test/solc-verify/StructsLocalStorage.sol
+++ b/test/solc-verify/StructsLocalStorage.sol
@@ -10,8 +10,8 @@ contract StructsLocalStorage {
         int z;
     }
 
+    T t1;
     S ss;
-    S ss2;
 
     function testSimple() public {
         ss.x = 1;
@@ -34,7 +34,31 @@ contract StructsLocalStorage {
         assert(ss.t.z == 6);
     }
 
+    function testMember() public {
+        ss.x = 1;
+        ss.t.z = 2;
+        t1.z = 3;
+        assert(ss.x == 1);
+        assert(ss.t.z == 2);
+        assert(t1.z == 3);
+
+        T storage tl = ss.t;
+        tl.z = 4;
+
+        assert(ss.x == 1);
+        assert(ss.t.z == 4);
+        assert(t1.z == 3);
+
+        tl = t1;
+        tl.z = 5;
+
+        assert(ss.x == 1);
+        assert(ss.t.z == 4);
+        assert(t1.z == 5);
+    }
+
     function() external payable {
         testSimple();
+        testMember();
     }
 }

--- a/test/solc-verify/StructsLocalStorage.sol
+++ b/test/solc-verify/StructsLocalStorage.sol
@@ -72,10 +72,72 @@ contract StructsLocalStorage {
         assert(s2.t.z == 1);
     }
 
+    S[2] s_arr;
+
+    function testArray() public {
+        s_arr[0].x = 1;
+        s_arr[0].t.z = 2;
+        s_arr[1].x = 3;
+        s_arr[1].t.z = 4;
+
+        uint i = 0;
+        S storage sl = s_arr[i];
+        i = i + 1;
+        sl.x = 5;
+        sl.t.z = 6;
+        assert(s_arr[0].x == 5);
+        assert(s_arr[0].t.z == 6);
+        assert(s_arr[1].x == 3);
+        assert(s_arr[1].t.z == 4);
+    }
+
+    function testArrayMember() public {
+        s_arr[0].x = 1;
+        s_arr[0].t.z = 2;
+        s_arr[1].x = 3;
+        s_arr[1].t.z = 4;
+
+        uint i = 0;
+        T storage tl = s_arr[i].t;
+        i = i + 1;
+        tl.z = 5;
+        assert(s_arr[0].x == 1);
+        assert(s_arr[0].t.z == 5);
+        assert(s_arr[1].x == 3);
+        assert(s_arr[1].t.z == 4);
+    }
+
+    T[2] t_arr;
+
+    function testReassign() public {
+        t_arr[0].z = 1;
+        t_arr[1].z = 2;
+        assert(t_arr[0].z == 1);
+        assert(t_arr[1].z == 2);
+
+        uint i = 0;
+        T storage tl = t_arr[i];
+        i++;
+        tl.z = 3;
+        assert(t_arr[0].z == 3);
+        assert(t_arr[1].z == 2);
+
+        tl = t_arr[i]; // Reassign
+        assert(t_arr[0].z == 3);
+        assert(t_arr[1].z == 2);
+
+        tl.z = 4;
+        assert(t_arr[0].z == 3);
+        assert(t_arr[1].z == 4);
+    }
+
     function() external payable {
         testSimple();
         testMember();
         testConditional(true);
         testConditional(false);
+        testArray();
+        testArrayMember();
+        testReassign();
     }
 }

--- a/test/solc-verify/StructsLocalStorage.sol.gold
+++ b/test/solc-verify/StructsLocalStorage.sol.gold
@@ -5,6 +5,7 @@ StructsLocalStorage::testArray: OK
 StructsLocalStorage::testArrayMember: OK
 StructsLocalStorage::testReassign: OK
 StructsLocalStorage::testAlternatingNesting: OK
+StructsLocalStorage::testMapping: OK
 StructsLocalStorage::[fallback]: OK
 StructsLocalStorage::[implicit_constructor]: OK
 No errors found.

--- a/test/solc-verify/StructsLocalStorage.sol.gold
+++ b/test/solc-verify/StructsLocalStorage.sol.gold
@@ -1,5 +1,6 @@
 StructsLocalStorage::testSimple: OK
 StructsLocalStorage::testMember: OK
+StructsLocalStorage::testConditional: OK
 StructsLocalStorage::[fallback]: OK
 StructsLocalStorage::[implicit_constructor]: OK
 No errors found.

--- a/test/solc-verify/StructsLocalStorage.sol.gold
+++ b/test/solc-verify/StructsLocalStorage.sol.gold
@@ -1,10 +1,4 @@
 StructsLocalStorage::testSimple: OK
-StructsLocalStorage::testMember: OK
-StructsLocalStorage::testMapping: OK
-StructsLocalStorage::testMappingMember: OK
-StructsLocalStorage::testArray: OK
-StructsLocalStorage::testArrayMember: OK
-StructsLocalStorage::testReassign: OK
 StructsLocalStorage::[fallback]: OK
 StructsLocalStorage::[implicit_constructor]: OK
 No errors found.

--- a/test/solc-verify/StructsLocalStorage.sol.gold
+++ b/test/solc-verify/StructsLocalStorage.sol.gold
@@ -1,4 +1,5 @@
 StructsLocalStorage::testSimple: OK
+StructsLocalStorage::testMember: OK
 StructsLocalStorage::[fallback]: OK
 StructsLocalStorage::[implicit_constructor]: OK
 No errors found.

--- a/test/solc-verify/StructsLocalStorage.sol.gold
+++ b/test/solc-verify/StructsLocalStorage.sol.gold
@@ -1,6 +1,9 @@
 StructsLocalStorage::testSimple: OK
 StructsLocalStorage::testMember: OK
 StructsLocalStorage::testConditional: OK
+StructsLocalStorage::testArray: OK
+StructsLocalStorage::testArrayMember: OK
+StructsLocalStorage::testReassign: OK
 StructsLocalStorage::[fallback]: OK
 StructsLocalStorage::[implicit_constructor]: OK
 No errors found.

--- a/test/solc-verify/StructsLocalStorage.sol.gold
+++ b/test/solc-verify/StructsLocalStorage.sol.gold
@@ -4,6 +4,7 @@ StructsLocalStorage::testConditional: OK
 StructsLocalStorage::testArray: OK
 StructsLocalStorage::testArrayMember: OK
 StructsLocalStorage::testReassign: OK
+StructsLocalStorage::testAlternatingNesting: OK
 StructsLocalStorage::[fallback]: OK
 StructsLocalStorage::[implicit_constructor]: OK
 No errors found.

--- a/test/solc-verify/StructsLocalStorageFunc.sol
+++ b/test/solc-verify/StructsLocalStorageFunc.sol
@@ -5,8 +5,14 @@ contract StructsLocalStorageFunc {
         int x;
     }
 
+    struct T {
+        S st1;
+        S st2;
+    }
+
     S s1;
     S s2;
+    T t;
 
     function set_x(S storage s, int _x) internal {
         s.x = _x;
@@ -17,9 +23,12 @@ contract StructsLocalStorageFunc {
         s2.x = 2;
         S storage sl1 = s1;
         S storage sl2 = s2;
+        S storage sl3 = t.st2;
         set_x(sl1, 1);
         set_x(sl2, 2);
+        set_x(sl3, 3);
         assert(s1.x == 1);
         assert(s2.x == 2);
+        assert(t.st2.x == 3);
     }
 }

--- a/test/solc-verify/StructsLocalStorageFunc.sol
+++ b/test/solc-verify/StructsLocalStorageFunc.sol
@@ -11,35 +11,32 @@ contract StructsLocalStorageFunc {
     }
 
     S s;
-    U u;
+    U[] u;
 
     function set_x_with_ptr(S storage s_ptr, int _x) internal {
         s_ptr.x = _x;
     }
 
-    function get_ptr(bool cond) internal view returns (S storage) {
-        if (cond) return u.s1;
-        else return u.s2;
+    function get_ptr(uint i, bool cond) internal view returns (S storage) {
+        if (cond) return u[i].s1;
+        else return u[i].s2;
     }
 
     function() external payable {
         // Calling a function
-        S storage sl1 = s;
-        S storage sl2 = u.s1;
-        S storage sl3 = u.s2;
-        set_x_with_ptr(sl1, 1);
-        set_x_with_ptr(sl2, 2);
-        set_x_with_ptr(sl3, 3);
+        set_x_with_ptr(s, 1);
+        set_x_with_ptr(u[0].s1, 2);
+        set_x_with_ptr(u[0].s2, 3);
         assert(s.x == 1);
-        assert(u.s1.x == 2);
-        assert(u.s2.x == 3);
+        assert(u[0].s1.x == 2);
+        assert(u[0].s2.x == 3);
 
         // Returning from function
-        u.s1.x = 1;
-        u.s2.x = 2;
-        S storage sl4 = get_ptr(true);
-        assert(sl4.x == 1);
-        sl4 = get_ptr(false);
-        assert(sl4.x == 2);
+        u[1].s1.x = 1;
+        u[2].s2.x = 2;
+        S storage s_ptr = get_ptr(1, true);
+        assert(s_ptr.x == 1);
+        s_ptr = get_ptr(2, false);
+        assert(s_ptr.x == 2);
     }
 }

--- a/test/solc-verify/StructsLocalStorageFunc.sol
+++ b/test/solc-verify/StructsLocalStorageFunc.sol
@@ -1,0 +1,25 @@
+pragma solidity >=0.5.0;
+
+contract StructsLocalStorageFunc {
+    struct S {
+        int x;
+    }
+
+    S s1;
+    S s2;
+
+    function set_x(S storage s, int _x) internal {
+        s.x = _x;
+    }
+
+    function() external payable {
+        s1.x = 1;
+        s2.x = 2;
+        S storage sl1 = s1;
+        S storage sl2 = s2;
+        set_x(sl1, 1);
+        set_x(sl2, 2);
+        assert(s1.x == 1);
+        assert(s2.x == 2);
+    }
+}

--- a/test/solc-verify/StructsLocalStorageFunc.sol
+++ b/test/solc-verify/StructsLocalStorageFunc.sol
@@ -11,7 +11,7 @@ contract StructsLocalStorageFunc {
     }
 
     S s;
-    U[] u;
+    U[3] u;
 
     function set_x_with_ptr(S storage s_ptr, int _x) internal {
         s_ptr.x = _x;

--- a/test/solc-verify/StructsLocalStorageFunc.sol
+++ b/test/solc-verify/StructsLocalStorageFunc.sol
@@ -10,8 +10,16 @@ contract StructsLocalStorageFunc {
         S s2;
     }
 
+    struct T {
+        int x;
+    }
+
     S s;
     U[3] u;
+
+    function set_t_x_with_ptr(T storage t_ptr, int _x) internal {
+        t_ptr.x = _x;
+    }
 
     function set_x_with_ptr(S storage s_ptr, int _x) internal {
         s_ptr.x = _x;

--- a/test/solc-verify/StructsLocalStorageFunc.sol
+++ b/test/solc-verify/StructsLocalStorageFunc.sol
@@ -5,30 +5,41 @@ contract StructsLocalStorageFunc {
         int x;
     }
 
-    struct T {
-        S st1;
-        S st2;
+    struct U {
+        S s1;
+        S s2;
     }
 
-    S s1;
-    S s2;
-    T t;
+    S s;
+    U u;
 
-    function set_x(S storage s, int _x) internal {
-        s.x = _x;
+    function set_x_with_ptr(S storage s_ptr, int _x) internal {
+        s_ptr.x = _x;
+    }
+
+    function get_ptr(bool cond) internal view returns (S storage) {
+        if (cond) return u.s1;
+        else return u.s2;
     }
 
     function() external payable {
-        s1.x = 1;
-        s2.x = 2;
-        S storage sl1 = s1;
-        S storage sl2 = s2;
-        S storage sl3 = t.st2;
-        set_x(sl1, 1);
-        set_x(sl2, 2);
-        set_x(sl3, 3);
-        assert(s1.x == 1);
-        assert(s2.x == 2);
-        assert(t.st2.x == 3);
+        // Calling a function
+        S storage sl1 = s;
+        S storage sl2 = u.s1;
+        S storage sl3 = u.s2;
+        set_x_with_ptr(sl1, 1);
+        set_x_with_ptr(sl2, 2);
+        set_x_with_ptr(sl3, 3);
+        assert(s.x == 1);
+        assert(u.s1.x == 2);
+        assert(u.s2.x == 3);
+
+        // Returning from function
+        u.s1.x = 1;
+        u.s2.x = 2;
+        S storage sl4 = get_ptr(true);
+        assert(sl4.x == 1);
+        sl4 = get_ptr(false);
+        assert(sl4.x == 2);
     }
 }

--- a/test/solc-verify/StructsLocalStorageFunc.sol.flags
+++ b/test/solc-verify/StructsLocalStorageFunc.sol.flags
@@ -1,0 +1,1 @@
+--show-warnings

--- a/test/solc-verify/StructsLocalStorageFunc.sol.gold
+++ b/test/solc-verify/StructsLocalStorageFunc.sol.gold
@@ -1,3 +1,7 @@
+test/solc-verify/StructsLocalStorageFunc.sol:20:5: Warning: Errors while translating function body, will be skipped
+test/solc-verify/StructsLocalStorageFunc.sol:18:5: Warning: Boogie: Unhandled default value, constructor verification might fail.
 StructsLocalStorageFunc::[fallback]: OK
 StructsLocalStorageFunc::[implicit_constructor]: OK
+StructsLocalStorageFunc::set_t_x_with_ptr: SKIPPED
 No errors found.
+Some functions were skipped. Use --verbose to see details.

--- a/test/solc-verify/StructsLocalStorageFunc.sol.gold
+++ b/test/solc-verify/StructsLocalStorageFunc.sol.gold
@@ -1,0 +1,3 @@
+StructsLocalStorageFunc::[fallback]: OK
+StructsLocalStorageFunc::[implicit_constructor]: OK
+No errors found.


### PR DESCRIPTION
### Description
Support local storage pointers by packing/unpacking them into an array, which encodes the path. Pointers involving mappings are limited to integer key types. There might be limitations for implicit conversions between storage and pointers.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] Used meaningful commit messages
