### PR TITLE
Provide partial results for unsupported features

### DIFF
--- a/libsolidity/ast/ASTBoogieConverter.cpp
+++ b/libsolidity/ast/ASTBoogieConverter.cpp
@@ -925,7 +925,7 @@ bool ASTBoogieConverter::visit(FunctionDefinition const& _node)
 	vector<bg::Block::Ref> blocks;
 	if (Error::containsOnlyWarnings(errorList))
 	{
-		if(!m_currentBlocks.top()->getStatements().empty())
+		if (!m_currentBlocks.top()->getStatements().empty())
 			blocks.push_back(m_currentBlocks.top());
 	}
 	else

--- a/libsolidity/ast/BoogieContext.cpp
+++ b/libsolidity/ast/BoogieContext.cpp
@@ -5,6 +5,7 @@
 #include <libsolidity/ast/TypeProvider.h>
 
 #include <liblangutil/ErrorReporter.h>
+#include <liblangutil/SourceReferenceFormatter.h>
 
 using namespace std;
 using namespace dev;
@@ -80,6 +81,14 @@ BoogieContext::BoogieContext(Encoding encoding,
 bg::VarDeclRef BoogieContext::tmpVar(bg::TypeDeclRef type, string prefix)
 {
 	return bg::Decl::variable(prefix + "#" + toString(nextId()), type);
+}
+
+void BoogieContext::printErrors(ostream& out)
+{
+	SourceReferenceFormatter formatter(out);
+	for (auto const& error: errorReporter()->errors())
+		formatter.printExceptionInformation(*error,
+				(error->type() == Error::Type::Warning) ? "Warning" : "solc-verify error");
 }
 
 string BoogieContext::mapDeclName(Declaration const& decl)

--- a/libsolidity/ast/BoogieContext.h
+++ b/libsolidity/ast/BoogieContext.h
@@ -125,6 +125,9 @@ public:
 	std::map<Declaration const*, TypePointer>& currentSumDecls() { return m_currentSumDecls; }
 	int nextId() { return m_nextId++; }
 	boogie::VarDeclRef tmpVar(boogie::TypeDeclRef type, std::string prefix = "tmp");
+
+	void printErrors(std::ostream& out);
+
 	/**
 	 * Map a declaration name to a name in Boogie
 	 */

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1275,11 +1275,7 @@ void CommandLineInterface::handleBoogie()
 		}
 	}
 
-	for (auto const& error: errorReporter.errors())
-	{
-		formatter.printExceptionInformation(*error,
-				(error->type() == Error::Type::Warning) ? "Warning" : "solc-verify error");
-	}
+	context.printErrors(serr(false));
 
 	if (!Error::containsOnlyWarnings(errorReporter.errors()))
 	{

--- a/solc/solc-verify.py.in
+++ b/solc/solc-verify.py.in
@@ -86,12 +86,12 @@ def main(tmpDir):
         compilerOutputStr = compilerOutput.decode('utf-8')
         if args.verbose:
             print(blueTxt('----- Compiler output -----'))
-            print(compilerOutputStr)
+            printVerbose(compilerOutputStr)
             print(blueTxt('---------------------------'))
     except subprocess.CalledProcessError as err:
         compilerOutputStr = err.output.decode('utf-8')
         print(yellowTxt('Error while running compiler, details:'))
-        print(compilerOutputStr)
+        printVerbose(compilerOutputStr)
         return ERROR_COMPILER
 
     # Run timer
@@ -135,7 +135,7 @@ def main(tmpDir):
             print(yellowTxt('Error while running verifier, details:'))
         if err.returncode != -9 or args.verbose:
             print(blueTxt('----- Verifier output -----'))
-            print(err.output.decode('utf-8'))
+            printVerbose(err.output.decode('utf-8'))
             print(blueTxt('---------------------------'))
         timer.cancel()
         return ERROR_PROCESS_ERROR
@@ -143,11 +143,11 @@ def main(tmpDir):
     verifierOutputStr = verifierOutput.decode('utf-8')
     if re.search('Boogie program verifier finished with', verifierOutputStr) == None:
         print(yellowTxt('Error while running verifier, details:'))
-        print(verifierOutputStr)
+        printVerbose(verifierOutputStr)
         return ERROR_BOOGIE_ERROR
     elif args.verbose:
         print(blueTxt('----- Verifier output -----'))
-        print(verifierOutputStr)
+        printVerbose(verifierOutputStr)
         print(blueTxt('---------------------------'))
 
     # Print warnings if requested
@@ -194,13 +194,21 @@ def main(tmpDir):
     if (re.match('Boogie program verifier finished with \\d+ verified, 0 errors', outputLines[-1])):
         print(greenTxt('No errors found.'))
         if 'inconclusive' in outputLines[-1]: print(yellowTxt('Inconclusive results.'))
-        if skipped > 0: print(yellowTxt('Some functions were skipped.'))
+        if skipped > 0: print(yellowTxt('Some functions were skipped. Use --verbose to see details.'))
         return ERROR_NO_ERRROR
     else:
         print(redTxt('Errors were found by the verifier.'))
         if warnings > 0 and not args.show_warnings:
             print(yellowTxt('Use --show-warnings to see the warnings for potential false alarms.'))
         return ERRORS_VERIFICATION
+
+def printVerbose(txt):
+    txt = txt.replace('Warning: ', yellowTxt('Warning') + ': ')
+    txt = txt.replace('Error: ', yellowTxt('Error') + ': ')
+    txt = txt.replace('solc-verify error: ', yellowTxt('solc-verify error') + ': ')
+    txt = txt.replace(']  error', ']  ' + redTxt('error'))
+    txt = txt.replace(']  verified', ']  ' + greenTxt('verified'))
+    print(txt)
 
 # Gets the line related to an error in the output
 def getRelatedLineFromBpl(outputLine, offset):

--- a/solc/solc-verify.py.in
+++ b/solc/solc-verify.py.in
@@ -43,6 +43,9 @@ def greenTxt(txt):
 def redTxt(txt):
     return '\033[91m' + txt + '\x1b[0m' if sys.stdout.isatty() else txt
 
+def blueTxt(txt):
+    return '\033[94m' + txt + '\x1b[0m' if sys.stdout.isatty() else txt
+
 def main(tmpDir):
     # Set up argument parser
     parser = argparse.ArgumentParser(description='Verify Solidity smart contracts.', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -76,15 +79,15 @@ def main(tmpDir):
         solcArgs += ' --boogie-mod-analysis'
     convertCommand = args.solc + ' ' + solcArgs
     if args.verbose:
-        print("Solc command: " + convertCommand)
+        print(blueTxt('Solc command: ') + convertCommand)
     compilerOutputStr = ''
     try:
         compilerOutput = subprocess.check_output(convertCommand, shell = True, stderr=subprocess.STDOUT)
         compilerOutputStr = compilerOutput.decode('utf-8')
         if args.verbose:
-            print('----- Compiler output -----')
+            print(blueTxt('----- Compiler output -----'))
             print(compilerOutputStr)
-            print('---------------------------')
+            print(blueTxt('---------------------------'))
     except subprocess.CalledProcessError as err:
         compilerOutputStr = err.output.decode('utf-8')
         print(yellowTxt('Error while running compiler, details:'))
@@ -121,7 +124,7 @@ def main(tmpDir):
 
     verifyCommand = 'mono ' + args.boogie + ' ' + bplFile + ' ' + boogieArgs
     if args.verbose:
-        print("Verifier command: " + verifyCommand)
+        print(blueTxt('Verifier command: ') + verifyCommand)
     try:
         verifierOutput = subprocess.check_output(verifyCommand, shell = True, stderr=subprocess.STDOUT)
         timer.cancel()
@@ -131,9 +134,9 @@ def main(tmpDir):
         else:
             print(yellowTxt('Error while running verifier, details:'))
         if err.returncode != -9 or args.verbose:
-            print('----- Verifier output -----')
+            print(blueTxt('----- Verifier output -----'))
             print(err.output.decode('utf-8'))
-            print('---------------------------')
+            print(blueTxt('---------------------------'))
         timer.cancel()
         return ERROR_PROCESS_ERROR
 
@@ -143,9 +146,9 @@ def main(tmpDir):
         print(verifierOutputStr)
         return ERROR_BOOGIE_ERROR
     elif args.verbose:
-        print('----- Verifier output -----')
+        print(blueTxt('----- Verifier output -----'))
         print(verifierOutputStr)
-        print('---------------------------')
+        print(blueTxt('---------------------------'))
 
     # Print warnings if requested
     warnings = 0

--- a/solc/solc-verify.py.in
+++ b/solc/solc-verify.py.in
@@ -182,9 +182,16 @@ def main(tmpDir):
             result = redTxt('ERROR') if 'error' in nextOutputLine else (yellowTxt('INCONCLUSIVE') if 'inconclusive' in nextOutputLine else greenTxt('OK'))
             print(getFunctionName(outputLine.replace('Verifying ', '').replace(' ...',''), bplFile) + ': ' + result)
 
+    skipped = 0
+    for line in open(bplFile).readlines():
+        if line.startswith('procedure ') and '{:skipped}' in line:
+            print(getMessage(line) + ': ' + yellowTxt('SKIPPED'))
+            skipped += 1
+
     if (re.match('Boogie program verifier finished with \\d+ verified, 0 errors', outputLines[-1])):
         print(greenTxt('No errors found.'))
         if 'inconclusive' in outputLines[-1]: print(yellowTxt('Inconclusive results.'))
+        if skipped > 0: print(yellowTxt('Some functions were skipped.'))
         return ERROR_NO_ERRROR
     else:
         print(redTxt('Errors were found by the verifier.'))

--- a/test/solc-verify/Partial.sol
+++ b/test/solc-verify/Partial.sol
@@ -1,0 +1,15 @@
+pragma solidity >=0.5.0;
+
+contract Partial {
+
+    /// @notice postcondition r == x + 1
+    function cannotverify(uint x) public pure returns (uint r) {
+        assembly {}
+        return x + 1;
+    }
+
+    function f() public pure {
+        uint x = cannotverify(5);
+        assert(x == 6);
+    }
+}

--- a/test/solc-verify/Partial.sol.gold
+++ b/test/solc-verify/Partial.sol.gold
@@ -1,0 +1,5 @@
+Partial::f: OK
+Partial::[implicit_constructor]: OK
+Partial::cannotverify: SKIPPED
+No errors found.
+Some functions were skipped.

--- a/test/solc-verify/Partial.sol.gold
+++ b/test/solc-verify/Partial.sol.gold
@@ -2,4 +2,4 @@ Partial::f: OK
 Partial::[implicit_constructor]: OK
 Partial::cannotverify: SKIPPED
 No errors found.
-Some functions were skipped.
+Some functions were skipped. Use --verbose to see details.


### PR DESCRIPTION
### Description
Previously if there was any error due to an unsupported element, no verification was performed at all. With this update, errors are localized to functions: if there is an error within the body of a function, the body will be ignored (with a warning message) and only the specification of the function will be used. This way we can still provide some results, with the assumption that the skipped functions are correct.

### Checklist
- [x] Code compiles correctly
- [x] All tests are passing
- [x] New tests have been created which fail without the change (if possible)
- [x] Used meaningful commit messages
