### PR TITLE
Strings as bytes

### DIFF
--- a/libsolidity/boogie/ASTBoogieUtils.cpp
+++ b/libsolidity/boogie/ASTBoogieUtils.cpp
@@ -837,7 +837,7 @@ ASTBoogieUtils::Value ASTBoogieUtils::defaultValueInternal(TypePointer type, Boo
 	{
 		// 0
 		auto lit = context.intLit(0, ASTBoogieUtils::getBits(type));
-		return {lit->tostring(), lit};
+		return {lit->toSMT2(), lit};
 	}
 	case Type::Category::Address:
 	case Type::Category::Contract:
@@ -845,19 +845,19 @@ ASTBoogieUtils::Value ASTBoogieUtils::defaultValueInternal(TypePointer type, Boo
 	{
 		// 0
 		auto lit = context.intLit(0, 256);
-		return {lit->tostring(), lit};
+		return {lit->toSMT2(), lit};
 	}
 	case Type::Category::Bool:
 	{
 		// False
 		auto lit = bg::Expr::lit(false);
-		return {lit->tostring(), lit};
+		return {lit->toSMT2(), lit};
 	}
 	case Type::Category::FixedBytes:
 	{
 		auto fbType = dynamic_cast<FixedBytesType const*>(type);
 		auto lit = context.intLit(0, fbType->numBytes() * 8);
-		return {lit->tostring(), lit};
+		return {lit->toSMT2(), lit};
 	}
 	case Type::Category::Struct:
 	{
@@ -910,7 +910,7 @@ ASTBoogieUtils::Value ASTBoogieUtils::defaultValueInternal(TypePointer type, Boo
 			args.push_back(arrLength);
 			auto bgExpr = bg::Expr::fn(arrConstr->getName(), args);
 			// SMT expression is constructed afterwards (not to be included in the const array function)
-			smtExpr = "(|" + arrConstr->getName() + "| " + smtExpr + " " + arrLength->tostring() + ")";
+			smtExpr = "(|" + arrConstr->getName() + "| " + smtExpr + " " + arrLength->toString() + ")";
 			return {smtExpr, bgExpr};
 		}
 		break;

--- a/libsolidity/boogie/ASTBoogieUtils.cpp
+++ b/libsolidity/boogie/ASTBoogieUtils.cpp
@@ -981,7 +981,7 @@ void ASTBoogieUtils::makeAssignInternal(AssignParam lhs, AssignParam rhs, langut
 		return;
 	}
 
-	if (auto lhsArrayType = dynamic_cast<ArrayType const*>(lhs.type))
+	if (dynamic_cast<ArrayType const*>(lhs.type))
 	{
 		if (dynamic_cast<ArrayType const*>(rhs.type) || dynamic_cast<StringLiteralType const*>(rhs.type))
 			makeArrayAssign(lhs, rhs, assocNode, context, result);

--- a/libsolidity/boogie/ASTBoogieUtils.cpp
+++ b/libsolidity/boogie/ASTBoogieUtils.cpp
@@ -891,8 +891,6 @@ ASTBoogieUtils::Value ASTBoogieUtils::defaultValueInternal(TypePointer type, Boo
 	case Type::Category::Array:
 	{
 		ArrayType const* arrayType = dynamic_cast<ArrayType const*>(type);
-		if (arrayType->isString())
-			return {"", nullptr};
 		if (arrayType->dataStoredIn(DataLocation::Storage))
 		{
 			auto keyType = context.intType(256);

--- a/libsolidity/boogie/ASTBoogieUtils.cpp
+++ b/libsolidity/boogie/ASTBoogieUtils.cpp
@@ -800,7 +800,36 @@ bg::Expr::Ref ASTBoogieUtils::defaultValue(TypePointer type, BoogieContext& cont
 	return defaultValueInternal(type, context).bgExpr;
 }
 
-ASTBoogieUtils::DefVal ASTBoogieUtils::defaultValueInternal(TypePointer type, BoogieContext& context)
+bg::Expr::Ref ASTBoogieUtils::stringValue(BoogieContext& context, std::string literal)
+{
+	auto keyType = context.intType(256);
+	auto valType = context.intType(8);
+	auto baseDefVal = defaultValueInternal(TypeProvider::byte(), context);
+
+	string smtType = "(Array " + keyType->getSmtType() + " " + valType->getSmtType() + ")";
+	string smtExpr = "((as const " + smtType + ") " + baseDefVal.smt + ")";
+
+	bg::FuncDeclRef arrConstr = context.getArrayConstructor(valType);
+	auto arrLength = context.intLit(literal.size(), 256);
+
+	bg::FuncDeclRef arrayValue0 = context.defaultArray(keyType, valType, smtExpr);
+	std::string arrayValue0Name = arrayValue0->getName();
+
+	auto innerArr = bg::Expr::fn(arrayValue0Name, vector<bg::Expr::Ref>());
+	for (size_t i = 0; i < literal.size(); ++ i)
+	{
+		auto iExpr = context.intLit(i, 256);
+		auto cExpr = context.intLit(literal[i], 8);
+		innerArr = bg::Expr::arrupd(innerArr, iExpr, cExpr);
+	}
+
+	// Construct the array with array setup
+	auto bgExpr = bg::Expr::fn(arrConstr->getName(), {innerArr, arrLength});
+
+	return bgExpr;
+}
+
+ASTBoogieUtils::Value ASTBoogieUtils::defaultValueInternal(TypePointer type, BoogieContext& context)
 {
 	switch (type->category()) // TODO: bitvectors
 	{
@@ -842,7 +871,7 @@ ASTBoogieUtils::DefVal ASTBoogieUtils::defaultValueInternal(TypePointer type, Bo
 			vector<string> memberDefValSmts;
 			for (auto& member: members)
 			{
-				DefVal memberDefaultValue = defaultValueInternal(member.type, context);
+				Value memberDefaultValue = defaultValueInternal(member.type, context);
 				if (memberDefaultValue.bgExpr == nullptr)
 					return {"", nullptr};
 				memberDefValExprs.push_back(memberDefaultValue.bgExpr);
@@ -949,12 +978,7 @@ void ASTBoogieUtils::makeAssignInternal(AssignParam lhs, AssignParam rhs, langut
 
 	if (auto lhsArrayType = dynamic_cast<ArrayType const*>(lhs.type))
 	{
-		if (lhsArrayType->isString())
-		{
-			makeBasicAssign(lhs, rhs, op, assocNode, context, result);
-			return;
-		}
-		if (dynamic_cast<ArrayType const*>(rhs.type))
+		if (dynamic_cast<ArrayType const*>(rhs.type) || dynamic_cast<StringLiteralType const*>(rhs.type))
 			makeArrayAssign(lhs, rhs, assocNode, context, result);
 		else
 			context.reportError(assocNode, "LHS is array but RHS is not");
@@ -1126,18 +1150,20 @@ void ASTBoogieUtils::makeStructAssign(AssignParam lhs, AssignParam rhs, ASTNode 
 
 void ASTBoogieUtils::makeArrayAssign(AssignParam lhs, AssignParam rhs, ASTNode const* assocNode, BoogieContext& context, AssignResult& result)
 {
+	// We can have arrays on LHS but RHS can be a string literal
 	auto lhsType = dynamic_cast<ArrayType const*>(lhs.type);
-	auto rhsType = dynamic_cast<ArrayType const*>(rhs.type);
+	auto rhsTypeArray = dynamic_cast<ArrayType const*>(rhs.type);
+	auto rhsTypeStringLiteral = dynamic_cast<StringLiteralType const*>(rhs.type);
 	solAssert(lhsType, "Expected array type for LHS");
-	solAssert(rhsType, "Expected array type for RHS");
-	if (lhsType->isString())
+	solAssert(rhsTypeArray || rhsTypeStringLiteral, "Expected array type for RHS");
+
+	DataLocation lhsLocation = lhsType->location();
+	DataLocation rhsLocation = rhsTypeArray ? rhsTypeArray->location() : DataLocation::Storage;
+
+	// Check if locations are compatible
+	if (lhsLocation != rhsLocation)
 	{
-		makeBasicAssign(lhs, rhs, Token::Assign, assocNode, context, result);
-		return;
-	}
-	if (lhsType->location() != rhsType->location())
-	{
-		if (lhsType->location() == DataLocation::Memory)
+		if (lhsLocation == DataLocation::Memory)
 		{
 			// Create new
 			auto varDecl = newArray(context.toBoogieType(lhsType, assocNode), context);
@@ -1145,9 +1171,10 @@ void ASTBoogieUtils::makeArrayAssign(AssignParam lhs, AssignParam rhs, ASTNode c
 			result.newStmts.push_back(bg::Stmt::assign(lhs.bgExpr, varDecl->getRefTo()));
 			lhs.bgExpr = context.getMemArray(lhs.bgExpr, context.toBoogieType(lhsType->baseType(), assocNode));
 		}
-		if (rhsType->location() == DataLocation::Memory || rhsType->location() == DataLocation::CallData)
-			rhs.bgExpr = context.getMemArray(rhs.bgExpr, context.toBoogieType(rhsType->baseType(), assocNode));
+		if (rhsLocation == DataLocation::Memory || rhsLocation == DataLocation::CallData)
+			rhs.bgExpr = context.getMemArray(rhs.bgExpr, context.toBoogieType(rhsTypeArray->baseType(), assocNode));
 	}
+
 	makeBasicAssign(lhs, rhs, Token::Assign, assocNode, context, result);
 }
 
@@ -1274,34 +1301,26 @@ void ASTBoogieUtils::deepCopyStruct(StructDefinition const* structDef,
 		else if (memberTypeCat == Type::Category::Array)
 		{
 			auto arrType = dynamic_cast<ArrayType const*>(memberType);
-			if (arrType->isString())
-				makeBasicAssign(
-						AssignParam{lhsSel, arrType, nullptr},
-						AssignParam{rhsSel, arrType, nullptr},
-						Token::Assign, assocNode, context, result);
-			else
+			if (lhsLoc == DataLocation::Memory)
 			{
-				if (lhsLoc == DataLocation::Memory)
-				{
-					// Create new
-					auto varDecl = ASTBoogieUtils::newArray(
-							context.toBoogieType(TypeProvider::withLocation(arrType, DataLocation::Memory, false), assocNode),
-							context);
-					result.newDecls.push_back(varDecl);
-					// Update member to point to new
-					makeBasicAssign(
-							AssignParam{lhsSel, memberType, nullptr},
-							AssignParam{varDecl->getRefTo(), memberType, nullptr},
-							Token::Assign, assocNode, context, result);
-				}
-				if (rhsLoc == DataLocation::Memory || rhsLoc == DataLocation::CallData)
-					rhsSel = context.getMemArray(rhsSel, context.toBoogieType(arrType->baseType(), assocNode));
-
+				// Create new
+				auto varDecl = ASTBoogieUtils::newArray(
+						context.toBoogieType(TypeProvider::withLocation(arrType, DataLocation::Memory, false), assocNode),
+						context);
+				result.newDecls.push_back(varDecl);
+				// Update member to point to new
 				makeBasicAssign(
 						AssignParam{lhsSel, memberType, nullptr},
-						AssignParam{rhsSel, memberType, nullptr},
+						AssignParam{varDecl->getRefTo(), memberType, nullptr},
 						Token::Assign, assocNode, context, result);
 			}
+			if (rhsLoc == DataLocation::Memory || rhsLoc == DataLocation::CallData)
+				rhsSel = context.getMemArray(rhsSel, context.toBoogieType(arrType->baseType(), assocNode));
+
+			makeBasicAssign(
+					AssignParam{lhsSel, memberType, nullptr},
+					AssignParam{rhsSel, memberType, nullptr},
+					Token::Assign, assocNode, context, result);
 		}
 		// For other types make the copy by updating the LHS with RHS
 		else

--- a/libsolidity/boogie/ASTBoogieUtils.h
+++ b/libsolidity/boogie/ASTBoogieUtils.h
@@ -199,8 +199,9 @@ public:
 	boogie::Expr::Ref defaultValue(TypePointer _type, BoogieContext& context);
 
 	/**
-	 * @param const Context
-	 * @return The value corresponding to the string literal
+	 * @param context Context
+	 * @param literal String literal
+	 * @returns The value corresponding to the string literal
 	 */
 	static
 	boogie::Expr::Ref stringValue(BoogieContext& context, std::string literal);

--- a/libsolidity/boogie/ASTBoogieUtils.h
+++ b/libsolidity/boogie/ASTBoogieUtils.h
@@ -198,14 +198,26 @@ public:
 	static
 	boogie::Expr::Ref defaultValue(TypePointer _type, BoogieContext& context);
 
+	/**
+	 * @param const Context
+	 * @return The value corresponding to the string literal
+	 */
+	static
+	boogie::Expr::Ref stringValue(BoogieContext& context, std::string literal);
+
 private:
-	/** Helper structure for getting default value of a type, including complex types such as arrays and structs. */
-	struct DefVal {
+
+	/**
+	 * Helper structure for a value of a type, including complex types such as arrays
+	 * and structs.
+	 */
+	struct Value {
 		std::string smt; // Default value as SMT expression (needed for arrays)
 		boogie::Expr::Ref bgExpr; // Default value as Boogie expression
 	};
+
 	static
-	DefVal defaultValueInternal(TypePointer _type, BoogieContext& context);
+	Value defaultValueInternal(TypePointer _type, BoogieContext& context);
 
 public:
 	/** Allocates a new memory struct. */

--- a/libsolidity/boogie/BoogieAst.cpp
+++ b/libsolidity/boogie/BoogieAst.cpp
@@ -8,15 +8,29 @@
 #include <set>
 #include <cassert>
 #include <boost/algorithm/string/predicate.hpp>
+#include <liblangutil/Exceptions.h>
 
 namespace boogie {
 
 unsigned Decl::uniqueId = 0;
 
-std::string Expr::tostring() const
+void Expr::printSMT2(std::ostream& out) const
+{
+	// By default print Boogie, override if differences
+	print(out);
+}
+
+std::string Expr::toString() const
 {
 	std::stringstream ss;
 	print(ss);
+	return ss.str();
+}
+
+std::string Expr::toSMT2() const
+{
+	std::stringstream ss;
+	printSMT2(ss);
 	return ss.str();
 }
 
@@ -671,6 +685,11 @@ void IntLit::print(std::ostream& os) const
 void BvLit::print(std::ostream& os) const
 {
 	os << val << "bv" << width;
+}
+
+void BvLit::printSMT2(std::ostream& os) const
+{
+	os << "(_ bv" << val << " " << width << ")";
 }
 
 void FPLit::print(std::ostream& os) const

--- a/libsolidity/boogie/BoogieAst.cpp
+++ b/libsolidity/boogie/BoogieAst.cpp
@@ -200,6 +200,11 @@ Expr::Ref Expr::neg(Ref e)
 	return std::make_shared<NegExpr const>(e);
 }
 
+Expr::Ref Expr::arrconst(TypeDeclRef arrType, Ref val)
+{
+	return std::make_shared<ArrConstExpr const>(arrType, val);
+}
+
 Expr::Ref Expr::arrsel(Ref b, Ref i)
 {
 	return std::make_shared<ArrSelExpr const>(b, i);
@@ -697,6 +702,11 @@ void QuantExpr::print(std::ostream& os) const
 	}
 	print_seq(os, vars, ", ");
 	os << " :: " << expr << ")";
+}
+
+void ArrConstExpr::print(std::ostream& os) const
+{
+	os << "((as const " << arrType << ") " << val << ")";
 }
 
 void ArrSelExpr::print(std::ostream& os) const

--- a/libsolidity/boogie/BoogieAst.h
+++ b/libsolidity/boogie/BoogieAst.h
@@ -77,6 +77,7 @@ public:
 	static Ref neq(Ref l, Ref r);
 	static Ref not_(Ref e);
 	static Ref neg(Ref e);
+	static Ref arrconst(TypeDeclRef arrType, Ref val);
 	static Ref arrsel(Ref b, Ref i);
 	static Ref arrupd(Ref b, Ref i, Ref v);
 	static Ref dtsel(Ref b, std::string mem, FuncDeclRef constr, DataTypeDeclRef dt);
@@ -235,6 +236,14 @@ protected:
 public:
 	UpdExpr(Ref base, Ref val) : base(base), val(val) {}
 	Ref getBase() const { return base; }
+};
+
+class ArrConstExpr : public Expr {
+	TypeDeclRef arrType;
+	Ref val;
+public:
+	ArrConstExpr(TypeDeclRef arrType, Ref val) : arrType(arrType), val(val) {}
+	void print(std::ostream& os) const override;
 };
 
 class ArrSelExpr : public SelExpr {

--- a/libsolidity/boogie/BoogieAst.h
+++ b/libsolidity/boogie/BoogieAst.h
@@ -36,7 +36,12 @@ public:
 
 	virtual ~Expr() {}
 	virtual void print(std::ostream& os) const = 0;
-	std::string tostring() const;
+	virtual void printSMT2(std::ostream& os) const;
+
+	std::string toString() const;
+	std::string toSMT2() const;
+
+	virtual bool isError() const { return false; }
 
 	/** Special expression to denote errors */
 	static Ref error();
@@ -86,9 +91,6 @@ public:
 	static Ref tuple(std::vector<Ref> const& e);
 
 	static Ref selectToUpdate(Ref sel, Ref value);
-
-	virtual
-	bool isError() const { return false; }
 };
 
 struct Binding
@@ -173,6 +175,7 @@ public:
 	}
 	std::string getVal() const { return val; }
 	void print(std::ostream& os) const override;
+	void printSMT2(std::ostream& os) const override;
 };
 
 class FPLit : public Expr {

--- a/libsolidity/boogie/BoogieContext.cpp
+++ b/libsolidity/boogie/BoogieContext.cpp
@@ -512,6 +512,55 @@ bg::TypeDeclRef BoogieContext::getStructType(StructDefinition const* structDef, 
 	return errType();
 }
 
+std::string BoogieContext::cleanupTypeName(std::string typeName)
+{
+	boost::replace_all(typeName, "[", "_k_");
+	boost::replace_all(typeName, "]", "_v_");
+	return typeName;
+}
+
+void BoogieContext::ensureArrayDeclarations(boogie::TypeDeclRef valueType)
+{
+	auto valueTypeName = valueType->getName();
+	auto valueTypeNameFind = m_arrConstrs.find(valueTypeName);
+	if (valueTypeNameFind != m_arrConstrs.end()) {
+		return;
+	}
+
+	solAssert(m_arrDataTypes.find(valueTypeName) == m_arrDataTypes.end(), "Should have been declared in parallel");
+
+	// Have to declare a new one, clean up the name
+	string valueTypeNameNoSpec = cleanupTypeName(valueTypeName);
+
+	// Datatype: [int]T + length
+	vector<bg::Binding> members = {
+			{ bg::Expr::id("arr"), bg::Decl::arraytype(intType(256), valueType) },
+			{ bg::Expr::id("length"), intType(256) }
+	};
+	boogie::DataTypeDeclRef datatypeDecl =  bg::Decl::datatype(valueTypeNameNoSpec + "_arr_type", members);
+	m_arrDataTypes[valueTypeName] = datatypeDecl;
+	addDecl(datatypeDecl);
+
+	// Constructor for
+	string name = valueTypeNameNoSpec + "_arr#constr";
+	boogie::FuncDeclRef arrayConstructor = bg::Decl::function(name, members, datatypeDecl, nullptr,
+			{ bg::Attr::attr("constructor") });
+	m_arrConstrs[valueTypeName] = arrayConstructor;
+	addDecl(arrayConstructor);
+}
+
+boogie::FuncDeclRef BoogieContext::getArrayConstructor(boogie::TypeDeclRef valueType)
+{
+	ensureArrayDeclarations(valueType);
+	return m_arrConstrs[valueType->getName()];
+}
+
+boogie::DataTypeDeclRef BoogieContext::getArrayDatatype(boogie::TypeDeclRef valueType)
+{
+	ensureArrayDeclarations(valueType);
+	return m_arrDataTypes[valueType->getName()];
+}
+
 bg::FuncDeclRef BoogieContext::defaultArray(bg::TypeDeclRef keyType, bg::TypeDeclRef valueType, string valueSmt)
 {
 	string funcName = "default_" + keyType->getName() + "_" + valueType->getName();
@@ -527,6 +576,26 @@ bg::FuncDeclRef BoogieContext::defaultArray(bg::TypeDeclRef keyType, bg::TypeDec
 		m_defaultArrays[funcName] = funcDecl;
 	}
 	return m_defaultArrays[funcName];
+}
+
+boogie::Expr::Ref BoogieContext::getMemArray(boogie::Expr::Ref arrPtrExpr, boogie::TypeDeclRef type)
+{
+
+	return boogie::Expr::arrsel(m_memArrs[type->getName()]->getRefTo(), arrPtrExpr);
+}
+
+boogie::Expr::Ref BoogieContext::getArrayLength(boogie::Expr::Ref arrayExpr, boogie::TypeDeclRef type)
+{
+	auto arrayConstructor = getArrayConstructor(type);
+	auto arrayDataType = getArrayDatatype(type);
+	return boogie::Expr::dtsel(arrayExpr, "length", arrayConstructor, arrayDataType);
+}
+
+boogie::Expr::Ref BoogieContext::getInnerArray(boogie::Expr::Ref arrayExpr, boogie::TypeDeclRef type)
+{
+	auto arrayConstructor = getArrayConstructor(type);
+	auto arrayDataType = getArrayDatatype(type);
+	return boogie::Expr::dtsel(arrayExpr, "arr", arrayConstructor, arrayDataType);
 }
 
 bg::TypeDeclRef BoogieContext::toBoogieType(TypePointer tp, ASTNode const* _associatedNode)
@@ -560,38 +629,13 @@ bg::TypeDeclRef BoogieContext::toBoogieType(TypePointer tp, ASTNode const* _asso
 	case Type::Category::Array:
 	{
 		auto arrType = dynamic_cast<ArrayType const*>(tp);
-
-		Type const* baseType = arrType->baseType();
-		bg::TypeDeclRef baseTypeBoogie = toBoogieType(baseType, _associatedNode);
-
-		string baseName = baseTypeBoogie->getName();
-		string baseNameNoSpec = baseName;
-		boost::replace_all(baseNameNoSpec, "[", "_k_");
-		boost::replace_all(baseNameNoSpec, "]", "_v_");
-
-		// Declare datatype and constructor if needed
-		if (m_arrDataTypes.find(baseName) == m_arrDataTypes.end())
-		{
-			// Datatype: [int]T + length
-			vector<bg::Binding> members = {
-					{bg::Expr::id("arr"), bg::Decl::arraytype(intType(256), baseTypeBoogie)},
-				{bg::Expr::id("length"), intType(256)}};
-			m_arrDataTypes[baseName] = bg::Decl::datatype(baseNameNoSpec + "_arr_type", members);
-
-			addDecl(m_arrDataTypes[baseName]);
-
-			// Constructor for datatype
-			vector<bg::Attr::Ref> attrs;
-			attrs.push_back(bg::Attr::attr("constructor"));
-			string name = baseNameNoSpec + "_arr#constr";
-			m_arrConstrs[baseName] = bg::Decl::function(name, members,
-					m_arrDataTypes[baseName], nullptr, attrs);
-			addDecl(m_arrConstrs[baseName]);
-		}
-
+		auto baseType = arrType->baseType();
+		auto baseTypeDecl = toBoogieType(baseType, _associatedNode);
+		string baseName = baseTypeDecl->getName();
+		
 		// Storage arrays are simply the data structures
 		if (arrType->location() == DataLocation::Storage)
-			return m_arrDataTypes[baseName];
+			return getArrayDatatype(baseTypeDecl);
 		// Memory arrays have an extra layer of indirection
 		// TODO: for precision, calldata arrays could be translated to different
 		// mappings than memory
@@ -600,14 +644,14 @@ bg::TypeDeclRef BoogieContext::toBoogieType(TypePointer tp, ASTNode const* _asso
 			if (m_memArrPtrTypes.find(baseName) == m_memArrPtrTypes.end())
 			{
 				// Pointer type
+				std::string baseNameNoSpec = cleanupTypeName(baseName);
 				m_memArrPtrTypes[baseName] = bg::Decl::customtype(baseNameNoSpec + "_arr_ptr");
 				addDecl(m_memArrPtrTypes[baseName]);
 
 				// The actual storage
+				auto arrayDataType = getArrayDatatype(baseTypeDecl);
 				m_memArrs[baseName] = bg::Decl::variable("mem_arr_" + baseNameNoSpec,
-						bg::Decl::arraytype(
-								m_memArrPtrTypes[baseName],
-								m_arrDataTypes[baseName]));
+						bg::Decl::arraytype(m_memArrPtrTypes[baseName], arrayDataType));
 				addDecl(m_memArrs[baseName]);
 			}
 			return m_memArrPtrTypes[baseName];

--- a/libsolidity/boogie/BoogieContext.cpp
+++ b/libsolidity/boogie/BoogieContext.cpp
@@ -632,7 +632,7 @@ bg::TypeDeclRef BoogieContext::toBoogieType(TypePointer tp, ASTNode const* _asso
 		auto baseType = arrType->baseType();
 		auto baseTypeDecl = toBoogieType(baseType, _associatedNode);
 		string baseName = baseTypeDecl->getName();
-		
+
 		// Storage arrays are simply the data structures
 		if (arrType->location() == DataLocation::Storage)
 			return getArrayDatatype(baseTypeDecl);

--- a/libsolidity/boogie/BoogieContext.cpp
+++ b/libsolidity/boogie/BoogieContext.cpp
@@ -522,11 +522,8 @@ std::string BoogieContext::cleanupTypeName(std::string typeName)
 void BoogieContext::ensureArrayDeclarations(boogie::TypeDeclRef valueType)
 {
 	auto valueTypeName = valueType->getName();
-	auto valueTypeNameFind = m_arrConstrs.find(valueTypeName);
-	if (valueTypeNameFind != m_arrConstrs.end()) {
+	if (m_arrConstrs.find(valueTypeName) != m_arrConstrs.end())
 		return;
-	}
-
 	solAssert(m_arrDataTypes.find(valueTypeName) == m_arrDataTypes.end(), "Should have been declared in parallel");
 
 	// Have to declare a new one, clean up the name

--- a/libsolidity/boogie/BoogieContext.cpp
+++ b/libsolidity/boogie/BoogieContext.cpp
@@ -577,7 +577,6 @@ bg::FuncDeclRef BoogieContext::defaultArray(bg::TypeDeclRef keyType, bg::TypeDec
 
 boogie::Expr::Ref BoogieContext::getMemArray(boogie::Expr::Ref arrPtrExpr, boogie::TypeDeclRef type)
 {
-
 	return boogie::Expr::arrsel(m_memArrs[type->getName()]->getRefTo(), arrPtrExpr);
 }
 

--- a/libsolidity/boogie/BoogieContext.h
+++ b/libsolidity/boogie/BoogieContext.h
@@ -212,10 +212,20 @@ public:
 	boogie::FuncDeclRef getStructConstructor(StructDefinition const* structDef);
 	boogie::TypeDeclRef getStructType(StructDefinition const* structDef, DataLocation loc);
 
-	boogie::FuncDeclRef getArrayConstructor(boogie::TypeDeclRef type) { return m_arrConstrs[type->getName()]; }
-	boogie::Expr::Ref getMemArray(boogie::Expr::Ref arrPtrExpr, boogie::TypeDeclRef type) { return boogie::Expr::arrsel(m_memArrs[type->getName()]->getRefTo(), arrPtrExpr); }
-	boogie::Expr::Ref getArrayLength(boogie::Expr::Ref arrayExpr, boogie::TypeDeclRef type) { return boogie::Expr::dtsel(arrayExpr, "length", m_arrConstrs[type->getName()], m_arrDataTypes[type->getName()]); }
-	boogie::Expr::Ref getInnerArray(boogie::Expr::Ref arrayExpr, boogie::TypeDeclRef type) { return boogie::Expr::dtsel(arrayExpr, "arr", m_arrConstrs[type->getName()], m_arrDataTypes[type->getName()]); }
+	/**
+	 * Ensures that the declarations of constructor and default values are declared for arrays
+	 * of the type valueType[].
+	 */
+	void ensureArrayDeclarations(boogie::TypeDeclRef valueType);
+	boogie::FuncDeclRef getArrayConstructor(boogie::TypeDeclRef valueType);
+	boogie::DataTypeDeclRef getArrayDatatype(boogie::TypeDeclRef valueType);
+
+	/** Clean a type name so that it is a valid ID */
+	static std::string cleanupTypeName(std::string typeName);
+
+	boogie::Expr::Ref getMemArray(boogie::Expr::Ref arrPtrExpr, boogie::TypeDeclRef type);
+	boogie::Expr::Ref getArrayLength(boogie::Expr::Ref arrayExpr, boogie::TypeDeclRef type);
+	boogie::Expr::Ref getInnerArray(boogie::Expr::Ref arrayExpr, boogie::TypeDeclRef type);
 
 	boogie::FuncDeclRef defaultArray(boogie::TypeDeclRef keyType, boogie::TypeDeclRef valueType, std::string valueSmt);
 

--- a/libsolidity/boogie/BoogieContext.h
+++ b/libsolidity/boogie/BoogieContext.h
@@ -73,7 +73,6 @@ private:
 	ASTBoogieStats m_stats;
 	boogie::Program m_program; // Result of the conversion is a single Boogie program (top-level node)
 
-	std::map<std::string, boogie::Decl::Ref> m_stringLiterals;
 	std::map<std::string, boogie::Decl::Ref> m_addressLiterals;
 
 	boogie::VarDeclRef m_boogieBalance;
@@ -206,7 +205,6 @@ public:
 	boogie::TypeDeclRef toBoogieType(TypePointer tp, ASTNode const* _associatedNode);
 	boogie::TypeDeclRef addressType() const;
 	boogie::TypeDeclRef boolType() const;
-	boogie::TypeDeclRef stringType() const;
 	boogie::TypeDeclRef intType(unsigned size) const;
 	boogie::TypeDeclRef localPtrType();
 	boogie::TypeDeclRef errType() const { return boogie::Decl::elementarytype("__ERROR_UNSUPPORTED_TYPE"); }

--- a/test/solc-verify/azure/AssetTransfer.sol.gold
+++ b/test/solc-verify/azure/AssetTransfer.sol.gold
@@ -1,4 +1,3 @@
-test/solc-verify/azure/AssetTransfer.sol:7:5: solc-verify warning: Unhandled default value, constructor verification might fail
 AssetTransfer::[constructor]: OK
 AssetTransfer::Terminate: OK
 AssetTransfer::Modify: OK

--- a/test/solc-verify/azure/BazaarItemListing.sol.gold
+++ b/test/solc-verify/azure/BazaarItemListing.sol.gold
@@ -1,5 +1,3 @@
-test/solc-verify/azure/BazaarItemListing.sol:12:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/BazaarItemListing.sol:68:5: solc-verify warning: Unhandled default value, constructor verification might fail
 ItemListing::[constructor]: OK
 ItemListing::BuyItem: OK
 Bazaar::[constructor]: OK

--- a/test/solc-verify/azure/DigitalLocker.sol.gold
+++ b/test/solc-verify/azure/DigitalLocker.sol.gold
@@ -1,10 +1,3 @@
-test/solc-verify/azure/DigitalLocker.sol:8:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/DigitalLocker.sol:9:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/DigitalLocker.sol:11:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/DigitalLocker.sol:12:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/DigitalLocker.sol:14:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/DigitalLocker.sol:15:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/DigitalLocker.sol:16:5: solc-verify warning: Unhandled default value, constructor verification might fail
 DigitalLocker::[constructor]: OK
 DigitalLocker::BeginReviewProcess: OK
 DigitalLocker::RejectApplication: OK

--- a/test/solc-verify/azure/HelloBlockchain.sol.gold
+++ b/test/solc-verify/azure/HelloBlockchain.sol.gold
@@ -1,5 +1,3 @@
-test/solc-verify/azure/HelloBlockchain.sol:13:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/HelloBlockchain.sol:14:5: solc-verify warning: Unhandled default value, constructor verification might fail
 HelloBlockchain::[constructor]: OK
 HelloBlockchain::SendRequest: OK
 HelloBlockchain::SendResponse: OK

--- a/test/solc-verify/azure/PingPongGame.sol.gold
+++ b/test/solc-verify/azure/PingPongGame.sol.gold
@@ -1,5 +1,3 @@
-test/solc-verify/azure/PingPongGame.sol:9:5: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/azure/PingPongGame.sol:64:5: solc-verify warning: Unhandled default value, constructor verification might fail
 Starter::[constructor]: OK
 Starter::StartPingPong: OK
 Starter::Pong: OK

--- a/test/solc-verify/azure/RefrigeratedTransportation.sol.gold
+++ b/test/solc-verify/azure/RefrigeratedTransportation.sol.gold
@@ -1,4 +1,3 @@
-test/solc-verify/azure/RefrigeratedTransportation.sol:25:5: solc-verify warning: Unhandled default value, constructor verification might fail
 RefrigeratedTransportation::[constructor]: OK
 RefrigeratedTransportation::IngestTelemetry: OK
 RefrigeratedTransportation::TransferResponsibility: OK

--- a/test/solc-verify/azure/RefrigeratedTransportationWithTime.sol.gold
+++ b/test/solc-verify/azure/RefrigeratedTransportationWithTime.sol.gold
@@ -1,4 +1,3 @@
-test/solc-verify/azure/RefrigeratedTransportationWithTime.sol:25:5: solc-verify warning: Unhandled default value, constructor verification might fail
 RefrigeratedTransportationWithTime::[constructor]: OK
 RefrigeratedTransportationWithTime::IngestTelemetry: OK
 RefrigeratedTransportationWithTime::TransferResponsibility: OK

--- a/test/solc-verify/azure/SimpleMarketplace.sol.gold
+++ b/test/solc-verify/azure/SimpleMarketplace.sol.gold
@@ -1,4 +1,3 @@
-test/solc-verify/azure/SimpleMarketplace.sol:12:5: solc-verify warning: Unhandled default value, constructor verification might fail
 SimpleMarketplace::[constructor]: OK
 SimpleMarketplace::MakeOffer: OK
 SimpleMarketplace::Reject: OK

--- a/test/solc-verify/basic/ECRecover.sol.gold
+++ b/test/solc-verify/basic/ECRecover.sol.gold
@@ -1,6 +1,4 @@
-test/solc-verify/basic/ECRecover.sol:12:3: solc-verify warning: Errors while translating function body, will be skipped
 ECRecover::verifyTwice: OK
+ECRecover::[fallback]: OK
 ECRecover::[implicit_constructor]: OK
-ECRecover::[fallback]: SKIPPED
-Some functions were skipped. Use --verbose to see details.
 No errors found.

--- a/test/solc-verify/basic/Keccak256.sol.gold
+++ b/test/solc-verify/basic/Keccak256.sol.gold
@@ -1,6 +1,4 @@
-test/solc-verify/basic/Keccak256.sol:12:3: solc-verify warning: Errors while translating function body, will be skipped
 Keccak256::hashTwice: OK
+Keccak256::[fallback]: OK
 Keccak256::[implicit_constructor]: OK
-Keccak256::[fallback]: SKIPPED
-Some functions were skipped. Use --verbose to see details.
 No errors found.

--- a/test/solc-verify/basic/RIPMD160.sol.gold
+++ b/test/solc-verify/basic/RIPMD160.sol.gold
@@ -1,6 +1,4 @@
-test/solc-verify/basic/RIPMD160.sol:12:3: solc-verify warning: Errors while translating function body, will be skipped
 RIPMD160::hashTwice: OK
+RIPMD160::[fallback]: OK
 RIPMD160::[implicit_constructor]: OK
-RIPMD160::[fallback]: SKIPPED
-Some functions were skipped. Use --verbose to see details.
 No errors found.

--- a/test/solc-verify/basic/SHA256.sol.gold
+++ b/test/solc-verify/basic/SHA256.sol.gold
@@ -1,6 +1,4 @@
-test/solc-verify/basic/SHA256.sol:12:3: solc-verify warning: Errors while translating function body, will be skipped
 SHA256::hashTwice: OK
+SHA256::[fallback]: OK
 SHA256::[implicit_constructor]: OK
-SHA256::[fallback]: SKIPPED
-Some functions were skipped. Use --verbose to see details.
 No errors found.

--- a/test/solc-verify/bitvector/DefaultBvMapping.sol
+++ b/test/solc-verify/bitvector/DefaultBvMapping.sol
@@ -1,0 +1,15 @@
+pragma solidity >=0.5.0;
+
+/// @notice invariant map[0] == 0
+contract DefaultBvMapping {
+
+    mapping(int16=>int32) map;
+
+    constructor() public {
+        assert(map[0] == 0);
+    }
+
+    function() external payable {
+        assert(map[0] == 0);
+    }
+}

--- a/test/solc-verify/bitvector/DefaultBvMapping.sol.flags
+++ b/test/solc-verify/bitvector/DefaultBvMapping.sol.flags
@@ -1,0 +1,1 @@
+--arithmetic bv

--- a/test/solc-verify/bitvector/DefaultBvMapping.sol.gold
+++ b/test/solc-verify/bitvector/DefaultBvMapping.sol.gold
@@ -1,0 +1,4 @@
+DefaultBvMapping::[constructor]: OK
+DefaultBvMapping::[fallback]: OK
+DefaultBvMapping::[receive_ether_selfdestruct]: OK
+No errors found.

--- a/test/solc-verify/issues/Issue066.sol.gold
+++ b/test/solc-verify/issues/Issue066.sol.gold
@@ -1,6 +1,3 @@
-test/solc-verify/issues/Issue066.sol:4:2: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/issues/Issue066.sol:5:2: solc-verify warning: Unhandled default value, constructor verification might fail
-test/solc-verify/issues/Issue066.sol:6:5: solc-verify warning: Unhandled default value, constructor verification might fail
 C::f: OK
 C::[implicit_constructor]: OK
 No errors found.

--- a/test/solc-verify/issues/Issue66.sol
+++ b/test/solc-verify/issues/Issue66.sol
@@ -4,7 +4,7 @@ contract Issue66 {
 	string a;
 	string b;
 
-  function f() public view {
+  	function f() public view {
 		string storage c = a;
 		string memory d = b;
 		d = string(c);

--- a/test/solc-verify/issues/Issue66.sol
+++ b/test/solc-verify/issues/Issue66.sol
@@ -1,0 +1,12 @@
+pragma solidity >=0.5.0;
+
+contract Issue66 {
+	string a;
+	string b;
+
+  function f() public view {
+		string storage c = a;
+		string memory d = b;
+		d = string(c);
+	}
+}

--- a/test/solc-verify/issues/Issue66.sol.gold
+++ b/test/solc-verify/issues/Issue66.sol.gold
@@ -1,0 +1,3 @@
+Issue66::f: OK
+Issue66::[implicit_constructor]: OK
+No errors found.


### PR DESCRIPTION
Moving representation of strings to array of bytes.

Interesting changes:
- `Expr::toSMT2` method to convert to SMT2 instead of Boogie. Needed to translate BV constants correctly
- Fixed initialization and getting of array constructors and datatyes (Issue #66) 
- Strings represented as arrays of bytes.