### PR TITLE
Further referencing storage pointers

### DIFF
--- a/libsolidity/boogie/ASTBoogieConverter.cpp
+++ b/libsolidity/boogie/ASTBoogieConverter.cpp
@@ -1379,18 +1379,13 @@ bool ASTBoogieConverter::visit(VariableDeclarationStatement const& _node)
 		{
 			solAssert(initialValue, "Uninitialized local storage pointer.");
 			bg::Expr::Ref init = convertExpression(*initialValue);
-			m_currentBlocks.top()->addStmt(bg::Stmt::comment("Packing local storage pointer " + declarations[0]->name()));
 
 			auto packed = StoragePtrHelper::packToLocalPtr(initialValue, init, m_context);
-			m_localDecls.push_back(packed.ptr);
-			for (auto stmt: packed.stmts)
-				m_currentBlocks.top()->addStmt(stmt);
-
 			auto varDecl = bg::Decl::variable(
 					m_context.mapDeclName(*declarations[0]),
 					m_context.localPtrType());
 			m_localDecls.push_back(varDecl);
-			m_currentBlocks.top()->addStmt(bg::Stmt::assign(varDecl->getRefTo(), packed.ptr->getRefTo()));
+			m_currentBlocks.top()->addStmt(bg::Stmt::assign(varDecl->getRefTo(), packed));
 			return false;
 		}
 	}

--- a/libsolidity/boogie/ASTBoogieExpressionConverter.cpp
+++ b/libsolidity/boogie/ASTBoogieExpressionConverter.cpp
@@ -550,11 +550,8 @@ bool ASTBoogieExpressionConverter::visit(FunctionCall const& _node)
 			{
 				if (structType->dataStoredIn(DataLocation::Storage))
 				{
-					auto res = StoragePtrHelper::packToLocalPtr(&memAccExpr->expression(), m_currentAddress, m_context);
-					m_newDecls.push_back(res.ptr);
-					for (auto stmt: res.stmts)
-						addSideEffect(stmt);
-					m_currentAddress = res.ptr->getRefTo();
+					auto packed = StoragePtrHelper::packToLocalPtr(&memAccExpr->expression(), m_currentAddress, m_context);
+					m_currentAddress = packed;
 				}
 			}
 		}

--- a/libsolidity/boogie/AssignHelper.cpp
+++ b/libsolidity/boogie/AssignHelper.cpp
@@ -62,12 +62,8 @@ void AssignHelper::makeAssignInternal(AssignParam lhs, AssignParam rhs, langutil
 	{
 		if (dynamic_cast<MappingType const*>(rhs.type))
 		{
-			result.newStmts.push_back(bg::Stmt::comment("Packing local storage pointer"));
 			auto packed = StoragePtrHelper::packToLocalPtr(rhs.expr, rhs.bgExpr, context);
-			result.newDecls.push_back(packed.ptr);
-			for (auto stmt: packed.stmts)
-				result.newStmts.push_back(stmt);
-			rhs.bgExpr = packed.ptr->getRefTo();
+			rhs.bgExpr = packed;
 			makeBasicAssign(lhs, rhs, Token::Assign, assocNode, context, result);
 		}
 		else
@@ -206,12 +202,8 @@ void AssignHelper::makeStructAssign(AssignParam lhs, AssignParam rhs, ASTNode co
 				}
 				else // Otherwise pack
 				{
-					result.newStmts.push_back(bg::Stmt::comment("Packing local storage pointer"));
 					auto packed = StoragePtrHelper::packToLocalPtr(rhs.expr, rhs.bgExpr, context);
-					result.newDecls.push_back(packed.ptr);
-					for (auto stmt: packed.stmts)
-						result.newStmts.push_back(stmt);
-					result.newStmts.push_back(bg::Stmt::assign(lhs.bgExpr, packed.ptr->getRefTo()));
+					result.newStmts.push_back(bg::Stmt::assign(lhs.bgExpr, packed));
 					return;
 				}
 			}
@@ -285,12 +277,8 @@ void AssignHelper::makeArrayAssign(AssignParam lhs, AssignParam rhs, ASTNode con
 		// Pack into local pointer (reassigning local pointer)
 		if (lhsType->isPointer() && rhsTypeArray && !rhsTypeArray->isPointer())
 		{
-			result.newStmts.push_back(bg::Stmt::comment("Packing local storage pointer"));
 			auto packed = StoragePtrHelper::packToLocalPtr(rhs.expr, rhs.bgExpr, context);
-			result.newDecls.push_back(packed.ptr);
-			for (auto stmt: packed.stmts)
-				result.newStmts.push_back(stmt);
-			rhs.bgExpr = packed.ptr->getRefTo();
+			rhs.bgExpr = packed;
 		}
 		else if (!lhsType->isPointer() && rhsTypeArray && rhsTypeArray->isPointer())
 		{

--- a/libsolidity/boogie/BoogieAst.h
+++ b/libsolidity/boogie/BoogieAst.h
@@ -13,7 +13,7 @@
 namespace boogie
 {
 
-using bigint = boost::multiprecision::int1024_t;
+using bigint = dev::bigint;
 
 class TypeDecl;
 using TypeDeclRef = std::shared_ptr<TypeDecl>;

--- a/libsolidity/boogie/StoragePtrHelper.cpp
+++ b/libsolidity/boogie/StoragePtrHelper.cpp
@@ -234,6 +234,8 @@ bg::Expr::Ref StoragePtrHelper::unpackInternal(Expression const* ptrExpr, boogie
 				bg::Expr::arrsel(ptrBgExpr, context.intLit(1, 256)));
 		for (unsigned i = 0; i < vars.size(); ++i)
 		{
+			if (vars[i]->isConstant())
+				continue;
 			auto subExpr = unpackInternal(ptrExpr, ptrBgExpr, vars[i], depth+1,
 					bg::Expr::arrsel(bg::Expr::id(context.mapDeclName(*vars[i])), context.boogieThis()->getRefTo()), context);
 			if (subExpr)
@@ -344,6 +346,8 @@ StoragePtrHelper::PackResult StoragePtrHelper::repack(Expression const* ptrExpr,
 		PackResult repacked = {{}, {}};
 		for (unsigned i = 0; i < vars.size(); ++i)
 		{
+			if (vars[i]->isConstant())
+				continue;
 			PackResult sub = repack(ptrExpr, ptrBgExpr, vars[i], depth+1, context);
 			if (!sub.exprs.empty())
 			{

--- a/libsolidity/boogie/StoragePtrHelper.h
+++ b/libsolidity/boogie/StoragePtrHelper.h
@@ -11,12 +11,6 @@ class BoogieContext;
 class StoragePtrHelper {
 
 public:
-	/* Result of packing a local storage pointer into an array. **/
-	struct PackResult {
-		boogie::Decl::Ref ptr; // Resulting pointer
-		std::list<boogie::Stmt::Ref> stmts; // Side effects of packing (filling the pointer array)
-	};
-
 	/**
 	 * Packs an expression into a local storage pointer.
 	 * @param expr Expression to be packed
@@ -25,7 +19,7 @@ public:
 	 * @returns Local pointer
 	 */
 	static
-	PackResult packToLocalPtr(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context);
+	boogie::Expr::Ref packToLocalPtr(Expression const* expr, boogie::Expr::Ref bgExpr, BoogieContext& context);
 
 	/**
 	 * Unpacks a local storage pointer into an access to storage.
@@ -37,6 +31,19 @@ public:
 	boogie::Expr::Ref unpackLocalPtr(Expression const* ptrExpr, boogie::Expr::Ref ptrBgExpr, BoogieContext& context);
 
 private:
+
+	/** Helper struct for internal operations during packing. */
+	struct PackResult {
+		std::vector<boogie::Expr::Ref> exprs; // Elements in the packed array
+	};
+
+	/**
+	 * Transform a list of integer expressions into a series of array writes.
+	 * For example, [3, i, 4] becomes constarray()[0 <- 3][1 <- i][2 <- 4].
+	 */
+	static
+	boogie::Expr::Ref toWriteExpr(std::vector<boogie::Expr::Ref> exprs, BoogieContext& context);
+
 	/**
 	 * Packs a path to a local storage into an array. E.g., 'ss[i].t' becomes [2, i, 3] if
 	 *  'ss' is the 2nd state var and 't' is the 3rd member.

--- a/libsolidity/boogie/StoragePtrHelper.h
+++ b/libsolidity/boogie/StoragePtrHelper.h
@@ -59,6 +59,8 @@ private:
 	static
 	boogie::Expr::Ref unpackInternal(Expression const* ptrExpr, boogie::Expr::Ref ptrBgExpr, Declaration const* decl, int depth, boogie::Expr::Ref base, BoogieContext& context);
 
+	static
+	PackResult repack(Expression const* ptrExpr, boogie::Expr::Ref ptrBgExpr, Declaration const* decl, int depth, BoogieContext& context);
 };
 
 }

--- a/libsolidity/boogie/StoragePtrHelper.h
+++ b/libsolidity/boogie/StoragePtrHelper.h
@@ -34,7 +34,8 @@ private:
 
 	/** Helper struct for internal operations during packing. */
 	struct PackResult {
-		std::vector<boogie::Expr::Ref> exprs; // Elements in the packed array
+		std::vector<boogie::Expr::Ref> conds; // Conditions
+		std::vector<std::vector<boogie::Expr::Ref>> exprs; // Elements in the packed array
 	};
 
 	/**

--- a/test/solc-verify/issues/Issue134.sol
+++ b/test/solc-verify/issues/Issue134.sol
@@ -1,0 +1,18 @@
+pragma solidity >=0.5.0;
+
+contract A {
+
+  string constant public s1 = "N1";
+  string s2 = "N2";
+
+  string title;
+
+  function f(string storage str) internal {
+    require(bytes(str).length > 0);
+    title = str;
+  }
+
+  constructor() public {
+    f(s2);
+  }
+}

--- a/test/solc-verify/issues/Issue134.sol.gold
+++ b/test/solc-verify/issues/Issue134.sol.gold
@@ -1,0 +1,2 @@
+A::[constructor]: OK
+No errors found.

--- a/test/solc-verify/structs/LocalStorageRepack.sol
+++ b/test/solc-verify/structs/LocalStorageRepack.sol
@@ -23,5 +23,10 @@ contract LocalStorageRepack {
         T storage tptr = sptr.t;
 
         assert(tptr.z == 11);
+
+        sptr = s2;
+        tptr = sptr.t;
+
+        assert(tptr.z == 22);
     }
 }

--- a/test/solc-verify/structs/LocalStorageRepack.sol
+++ b/test/solc-verify/structs/LocalStorageRepack.sol
@@ -22,6 +22,6 @@ contract LocalStorageRepack {
         S storage sptr = s1;
         T storage tptr = sptr.t;
 
-        assert(tptr.z == 1);
+        assert(tptr.z == 11);
     }
 }

--- a/test/solc-verify/structs/LocalStorageRepack.sol
+++ b/test/solc-verify/structs/LocalStorageRepack.sol
@@ -1,6 +1,10 @@
 pragma solidity>=0.5.0;
 
 contract LocalStorageRepack {
+    struct P {
+        S s;
+    }
+
     struct S {
         int x;
         T t;
@@ -12,21 +16,30 @@ contract LocalStorageRepack {
 
     S s1;
     S s2;
+    P p;
 
     function() external payable {
         s1.x = 1;
         s1.t.z = 11;
         s2.x = 2;
         s2.t.z = 22;
+        p.s.x = 3;
+        p.s.t.z = 33;
 
         S storage sptr = s1;
-        T storage tptr = sptr.t;
-
+        T storage tptr = sptr.t; // Further reference
         assert(tptr.z == 11);
 
         sptr = s2;
-        tptr = sptr.t;
-
+        tptr = sptr.t; // Further reference
         assert(tptr.z == 22);
+
+        sptr = p.s;
+        tptr = sptr.t; // Further reference
+        assert(tptr.z == 33);
+
+        P storage pptr = p;
+        tptr = pptr.s.t; // Further reference
+        assert(tptr.z == 33);
     }
 }

--- a/test/solc-verify/structs/LocalStorageRepack.sol
+++ b/test/solc-verify/structs/LocalStorageRepack.sol
@@ -1,0 +1,27 @@
+pragma solidity>=0.5.0;
+
+contract LocalStorageRepack {
+    struct S {
+        int x;
+        T t;
+    }
+
+    struct T {
+        int z;
+    }
+
+    S s1;
+    S s2;
+
+    function() external payable {
+        s1.x = 1;
+        s1.t.z = 11;
+        s2.x = 2;
+        s2.t.z = 22;
+
+        S storage sptr = s1;
+        T storage tptr = sptr.t;
+
+        assert(tptr.z == 1);
+    }
+}

--- a/test/solc-verify/structs/LocalStorageRepack.sol
+++ b/test/solc-verify/structs/LocalStorageRepack.sol
@@ -17,6 +17,7 @@ contract LocalStorageRepack {
     S s1;
     S s2;
     P p;
+    S[] s_arr;
 
     function() external payable {
         s1.x = 1;
@@ -25,6 +26,9 @@ contract LocalStorageRepack {
         s2.t.z = 22;
         p.s.x = 3;
         p.s.t.z = 33;
+        require(s_arr.length == 0);
+        s_arr.push(S(4, T(44)));
+        s_arr.push(S(5, T(55)));
 
         S storage sptr = s1;
         T storage tptr = sptr.t; // Further reference
@@ -41,5 +45,17 @@ contract LocalStorageRepack {
         P storage pptr = p;
         tptr = pptr.s.t; // Further reference
         assert(tptr.z == 33);
+
+        sptr = s_arr[0];
+        tptr = sptr.t; // Further reference
+        assert(tptr.z == 44);
+
+        sptr = s_arr[1];
+        tptr = sptr.t; // Further reference
+        assert(tptr.z == 55);
+
+        S[] storage saptr = s_arr;
+        tptr = saptr[0].t; // Further reference
+        assert(tptr.z == 44);
     }
 }

--- a/test/solc-verify/structs/LocalStorageRepack.sol.gold
+++ b/test/solc-verify/structs/LocalStorageRepack.sol.gold
@@ -1,0 +1,3 @@
+LocalStorageRepack::[fallback]: OK
+LocalStorageRepack::[implicit_constructor]: OK
+No errors found.


### PR DESCRIPTION
Previously the base expression to be packed had to start with a state variable. This PR introduces support for expressions that start with a storage pointer. This way, storage pointers can be further referenced to other storage pointers. The implementation is done by unpacking/repacking.

Fixes #133 and #134